### PR TITLE
Adds CLI option to configure Cluster ID

### DIFF
--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -74,6 +74,8 @@ type TLSOptions struct {
 	RootCAConfigMapName        string
 	ServingAddress             string
 	ServingCertificateDuration time.Duration
+
+	ClusterID string
 }
 
 type KubeOptions struct {
@@ -116,7 +118,7 @@ func (o *Options) Complete() error {
 		return fmt.Errorf("failed to build kubernetes client: %s", err)
 	}
 
-	o.Auther = authenticate.NewKubeJWTAuthenticator(o.KubeClient, "Kubernetes", nil, spiffe.GetTrustDomain(), jwt.PolicyThirdParty)
+	o.Auther = authenticate.NewKubeJWTAuthenticator(o.KubeClient, o.ClusterID, nil, spiffe.GetTrustDomain(), jwt.PolicyThirdParty)
 
 	cmClient, err := cmversioned.NewForConfig(o.RestConfig)
 	if err != nil {
@@ -194,6 +196,9 @@ func (t *TLSOptions) addFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&t.RootCAConfigMapName,
 		"root-ca-configmap-name", "istio-ca-root-cert",
 		"The ConfigMap name to store the root CA certificate in each namespace.")
+
+	fs.StringVar(&t.ClusterID, "cluster-id", "Kubernetes",
+		"The ID of the istio cluster to verify.")
 }
 
 func (c *CertManagerOptions) addFlags(fs *pflag.FlagSet) {

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -33,6 +33,8 @@ spec:
           - "--readiness-probe-port={{.Values.agent.readinessProbe.port}}"
           - "--readiness-probe-path={{.Values.agent.readinessProbe.path}}"
 
+          - "--cluster-id={{.Values.agent.clusterID}}"
+
           - "--serving-address={{.Values.agent.servingAddress}}:{{.Values.agent.servingPort}}"
           - "--serving-certificate-duration={{.Values.agent.certificateDuration}}"
           - "--root-ca-configmap-name={{.Values.agent.rootCAConfigMapName}}"

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -24,6 +24,9 @@ agent:
     # -- Path to expose istio-csr HTTP readiness probe on default network interface.
     path: "/readyz"
 
+  # -- The istio cluster ID to verify incoming CSRs.
+  clusterID: "Kubernetes"
+
   # -- Container address to serve istio-csr gRPC service.
   servingAddress: 0.0.0.0
   # -- Container port to serve istio-csr gRPC service.


### PR DESCRIPTION
/assign @jakexks 
fixes #27 

This PR exposes the option to allow configuring the Cluster ID. This is used to configure the authenticator to allow requests from istio which doesn't use the default Cluster ID.