### PR TITLE
Intoduce more in-depth CSR extension validation

### DIFF
--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -114,23 +114,14 @@ func (authn *mockAuthenticator) Authenticate(ctx context.Context) (*authenticate
 	}, nil
 }
 
-func genCSR(t *testing.T, mods ...gen.CSRModifier) []byte {
-	csr, err := gen.CSR(mods...)
-	if err != nil {
-		t.Fatal(err)
+func newMockAuthn(ids []string, errMsg string) *mockAuthenticator {
+	return &mockAuthenticator{
+		identities: ids,
+		errMsg:     errMsg,
 	}
-
-	return csr
 }
 
 func TestAuthRequest(t *testing.T) {
-	newMockAuthn := func(ids []string, errMsg string) *mockAuthenticator {
-		return &mockAuthenticator{
-			identities: ids,
-			errMsg:     errMsg,
-		}
-	}
-
 	tests := map[string]struct {
 		authn       *mockAuthenticator
 		inpCSR      []byte
@@ -157,7 +148,7 @@ func TestAuthRequest(t *testing.T) {
 		},
 		"if auth returns identities, but given csr has dns, error": {
 			authn: newMockAuthn([]string{"spiffe://foo", "spiffe://bar"}, ""),
-			inpCSR: genCSR(t,
+			inpCSR: gen.MustCSR(t,
 				gen.SetCSRIdentities([]string{"spiffe://foo", "spiffe://bar"}),
 				gen.SetCSRDNS([]string{"example.com", "jetstack.io"}),
 			),
@@ -166,7 +157,7 @@ func TestAuthRequest(t *testing.T) {
 		},
 		"if auth returns identities, but given csr has ips, error": {
 			authn: newMockAuthn([]string{"spiffe://foo", "spiffe://bar"}, ""),
-			inpCSR: genCSR(t,
+			inpCSR: gen.MustCSR(t,
 				gen.SetCSRIdentities([]string{"spiffe://foo", "spiffe://bar"}),
 				gen.SetCSRIPs([]string{"8.8.8.8"}),
 			),
@@ -175,7 +166,7 @@ func TestAuthRequest(t *testing.T) {
 		},
 		"if auth returns identities, but given csr has common name, error": {
 			authn: newMockAuthn([]string{"spiffe://foo", "spiffe://bar"}, ""),
-			inpCSR: genCSR(t,
+			inpCSR: gen.MustCSR(t,
 				gen.SetCSRIdentities([]string{"spiffe://foo", "spiffe://bar"}),
 				gen.SetCSRCommonName("jetstack.io"),
 			),
@@ -184,7 +175,7 @@ func TestAuthRequest(t *testing.T) {
 		},
 		"if auth returns identities, but given csr has email addresses, error": {
 			authn: newMockAuthn([]string{"spiffe://foo", "spiffe://bar"}, ""),
-			inpCSR: genCSR(t,
+			inpCSR: gen.MustCSR(t,
 				gen.SetCSRIdentities([]string{"spiffe://foo", "spiffe://bar"}),
 				gen.SetCSREmails([]string{"joshua.vanleeuwen@jetstack.io"}),
 			),
@@ -193,7 +184,7 @@ func TestAuthRequest(t *testing.T) {
 		},
 		"if auth returns identities, but given csr has miss matched identities, error": {
 			authn: newMockAuthn([]string{"spiffe://foo", "spiffe://bar"}, ""),
-			inpCSR: genCSR(t,
+			inpCSR: gen.MustCSR(t,
 				gen.SetCSRIdentities([]string{"spiffe://josh", "spiffe://bar"}),
 			),
 			expIdenties: "spiffe://foo,spiffe://bar",
@@ -201,7 +192,7 @@ func TestAuthRequest(t *testing.T) {
 		},
 		"if auth returns identities, but given csr has subset of identities, error": {
 			authn: newMockAuthn([]string{"spiffe://foo", "spiffe://bar"}, ""),
-			inpCSR: genCSR(t,
+			inpCSR: gen.MustCSR(t,
 				gen.SetCSRIdentities([]string{"spiffe://bar"}),
 			),
 			expIdenties: "spiffe://foo,spiffe://bar",
@@ -209,7 +200,7 @@ func TestAuthRequest(t *testing.T) {
 		},
 		"if auth returns identities, but given csr has more identities, error": {
 			authn: newMockAuthn([]string{"spiffe://foo", "spiffe://bar"}, ""),
-			inpCSR: genCSR(t,
+			inpCSR: gen.MustCSR(t,
 				gen.SetCSRIdentities([]string{"spiffe://foo", "spiffe://bar", "spiffe://joshua.vanleeuwen"}),
 			),
 			expIdenties: "spiffe://foo,spiffe://bar",
@@ -217,7 +208,7 @@ func TestAuthRequest(t *testing.T) {
 		},
 		"if auth returns identities, and given csr matches identities, return true": {
 			authn: newMockAuthn([]string{"spiffe://foo", "spiffe://bar"}, ""),
-			inpCSR: genCSR(t,
+			inpCSR: gen.MustCSR(t,
 				gen.SetCSRIdentities([]string{"spiffe://foo", "spiffe://bar"}),
 			),
 			expIdenties: "spiffe://foo,spiffe://bar",
@@ -225,7 +216,7 @@ func TestAuthRequest(t *testing.T) {
 		},
 		"if auth returns single id, and given csr matches id, return true": {
 			authn: newMockAuthn([]string{"spiffe://foo"}, ""),
-			inpCSR: genCSR(t,
+			inpCSR: gen.MustCSR(t,
 				gen.SetCSRIdentities([]string{"spiffe://foo"}),
 			),
 			expIdenties: "spiffe://foo",

--- a/pkg/server/internal/extensions/extensions.go
+++ b/pkg/server/internal/extensions/extensions.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extensions
+
+import (
+	"bytes"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"fmt"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+const (
+	// Mapping from the type of an identity to the OID tag value for the X.509
+	// SAN field (see https://tools.ietf.org/html/rfc5280#appendix-A.2)
+	//
+	// SubjectAltName ::= GeneralNames
+	//
+	// GeneralNames ::= SEQUENCE SIZE (1..MAX) OF GeneralName
+	//
+	// GeneralName ::= CHOICE {
+	//      uniformResourceIdentifier       [6]     IA5String,
+	// }
+	asn1TagURI = 6
+)
+
+var (
+	// Copied from x509.go
+	oidExtensionKeyUsage         = asn1.ObjectIdentifier{2, 5, 29, 15}
+	oidExtensionExtendedKeyUsage = asn1.ObjectIdentifier{2, 5, 29, 37}
+	oidExtensionSubjectAltName   = asn1.ObjectIdentifier{2, 5, 29, 17}
+
+	oidExtKeyUsageServerAuth = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 1}
+	oidExtKeyUsageClientAuth = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 2}
+
+	allowedKeyUsages = [][]byte{
+		{3, 2, 7, 128}, // x509.KeyUsageDigitalSignature
+		{3, 2, 5, 32},  // x509.KeyUsageKeyEncipherment
+	}
+)
+
+// ValidateCSRExtentions validates the given certificate signing request
+// contains only valid extensions, including URI sans, key usages, and extended
+// key usages. Any other extensions will error.
+func ValidateCSRExtentions(csr *x509.CertificateRequest) error {
+	var el []error
+
+	if len(csr.ExtraExtensions) > 0 {
+		el = append(el, fmt.Errorf("forbidden extensions: %v", csr.Extensions))
+	}
+
+	for _, extension := range csr.Extensions {
+		switch extension.Id.String() {
+		case oidExtensionSubjectAltName.String():
+			el = append(el, validateExtensionURI(extension))
+
+		case oidExtensionKeyUsage.String():
+			el = append(el, validateKeyUsageExtension(extension.Value))
+
+		case oidExtensionExtendedKeyUsage.String():
+			el = append(el, validateExtendedKeyUsageExtension(extension))
+
+		default:
+			el = append(el, fmt.Errorf("forbidden extension: %s", extension.Id))
+		}
+	}
+
+	return utilerrors.NewAggregate(el)
+}
+
+// validateKeyUsageExtension validates that the passed extension value contains
+// accepted key usages
+func validateKeyUsageExtension(value []byte) error {
+	if len(value) != 4 {
+		return fmt.Errorf("forbidden key usage: %v", value)
+	}
+
+	extValue := make([]byte, len(value))
+	copy(extValue, value)
+	for _, usage := range allowedKeyUsages {
+		for i, b := range usage {
+			extValue[i] = extValue[i] &^ b
+		}
+	}
+
+	if !bytes.Equal(extValue, []byte{0, 0, 0, 0}) {
+		return fmt.Errorf("forbidden key usage: %v", value)
+	}
+
+	return nil
+}
+
+// validateExtendedKeyUsageExtension validates that the passed extension
+// contains accepted extended key usages
+func validateExtendedKeyUsageExtension(extension pkix.Extension) error {
+	if !extension.Id.Equal(oidExtensionExtendedKeyUsage) {
+		return fmt.Errorf("non extended key usage extension: %s", extension.Id)
+	}
+
+	var asn1ExtendedUsages []asn1.ObjectIdentifier
+	_, err := asn1.Unmarshal(extension.Value, &asn1ExtendedUsages)
+	if err != nil {
+		return fmt.Errorf("failed to parse extended key usages: %s", err)
+	}
+
+	var el []error
+	for _, usage := range asn1ExtendedUsages {
+		if !usage.Equal(oidExtKeyUsageClientAuth) && !usage.Equal(oidExtKeyUsageServerAuth) {
+			el = append(el, fmt.Errorf("forbidden extended key usage: %s", usage))
+		}
+	}
+
+	return utilerrors.NewAggregate(el)
+}
+
+// validateExtensionURI validates that the passed extension is a correctly
+// encoded URI SAN
+func validateExtensionURI(ext pkix.Extension) error {
+	if !ext.Id.Equal(oidExtensionSubjectAltName) {
+		return fmt.Errorf("extension is not a SAN type: %s", ext.Id)
+	}
+	var sequence asn1.RawValue
+	if rest, err := asn1.Unmarshal(ext.Value, &sequence); err != nil {
+		return fmt.Errorf("failed to unmarshal san extension: %v", err)
+	} else if len(rest) != 0 {
+		return fmt.Errorf("san extension incorrectly encoded: %v", ext.Value)
+	}
+
+	// Check the rawValue is a sequence.
+	if !sequence.IsCompound || sequence.Tag != asn1.TagSequence || sequence.Class != asn1.ClassUniversal {
+		return fmt.Errorf("san extension is incorrectly encoded: %v", ext.Value)
+	}
+
+	for bytes := sequence.Bytes; len(bytes) > 0; {
+		var (
+			rawValue asn1.RawValue
+			err      error
+		)
+
+		bytes, err = asn1.Unmarshal(bytes, &rawValue)
+		if err != nil {
+			return err
+		}
+
+		if rawValue.Tag != asn1TagURI {
+			return fmt.Errorf("non uri san extension given: %s", rawValue.Bytes)
+		}
+	}
+
+	return nil
+}

--- a/pkg/server/internal/extensions/extensions_test.go
+++ b/pkg/server/internal/extensions/extensions_test.go
@@ -1,0 +1,396 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extensions
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"fmt"
+	"testing"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	pkiutil "github.com/jetstack/cert-manager/pkg/util/pki"
+)
+
+var (
+	disallowedX509KeyUsages = []interface{}{
+		x509.KeyUsageContentCommitment,
+		x509.KeyUsageDataEncipherment,
+		x509.KeyUsageKeyAgreement,
+		x509.KeyUsageCertSign,
+		x509.KeyUsageCRLSign,
+		x509.KeyUsageEncipherOnly,
+		x509.KeyUsageDecipherOnly,
+	}
+
+	allowedX509KeyUsages = []interface{}{
+		x509.KeyUsageDigitalSignature,
+		x509.KeyUsageKeyEncipherment,
+	}
+
+	disallowedX509ExtKeyUsages = []interface{}{
+		x509.ExtKeyUsageAny,
+		x509.ExtKeyUsageCodeSigning,
+		x509.ExtKeyUsageEmailProtection,
+		x509.ExtKeyUsageIPSECEndSystem,
+		x509.ExtKeyUsageIPSECTunnel,
+		x509.ExtKeyUsageIPSECUser,
+		x509.ExtKeyUsageTimeStamping,
+		x509.ExtKeyUsageOCSPSigning,
+		x509.ExtKeyUsageMicrosoftServerGatedCrypto,
+		x509.ExtKeyUsageNetscapeServerGatedCrypto,
+		x509.ExtKeyUsageMicrosoftCommercialCodeSigning,
+		x509.ExtKeyUsageMicrosoftKernelCodeSigning,
+	}
+
+	allowedX509ExtKeyUsages = []interface{}{
+		x509.ExtKeyUsageServerAuth,
+		x509.ExtKeyUsageClientAuth,
+	}
+)
+
+func TestValidateCSRExtentions(t *testing.T) {
+	sk, err := pkiutil.GenerateRSAPrivateKey(2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := map[string]struct {
+		emails []string
+		dns    []string
+		uris   []string
+		ips    []string
+		usages []cmapi.KeyUsage
+		expErr bool
+	}{
+		"if single URI name exists, shouldn't error": {
+			uris:   []string{"spiffe://foo.bar"},
+			expErr: false,
+		},
+		"if single URI name exist with allowed usages, shouldn't error": {
+			uris: []string{"spiffe://foo.bar"},
+			usages: []cmapi.KeyUsage{
+				cmapi.UsageDigitalSignature,
+				cmapi.UsageKeyEncipherment,
+				cmapi.UsageClientAuth,
+				cmapi.UsageServerAuth,
+			},
+			expErr: false,
+		},
+		"if multiple URI names exist with allowed usages, shouldn't error": {
+			uris: []string{"spiffe://foo.bar", "spiffe://bar.foo"},
+			usages: []cmapi.KeyUsage{
+				cmapi.UsageDigitalSignature,
+				cmapi.UsageKeyEncipherment,
+				cmapi.UsageClientAuth,
+				cmapi.UsageServerAuth,
+			},
+			expErr: false,
+		},
+		"if multiple URI names exist, dns name, and allowed usages, should error": {
+			uris: []string{"spiffe://foo.bar", "spiffe://bar.foo"},
+			dns:  []string{"foo.bar"},
+			usages: []cmapi.KeyUsage{
+				cmapi.UsageDigitalSignature,
+				cmapi.UsageKeyEncipherment,
+				cmapi.UsageClientAuth,
+				cmapi.UsageServerAuth,
+			},
+			expErr: true,
+		},
+		"if multiple URI names exist, ips, and allowed usages, should error": {
+			uris: []string{"spiffe://foo.bar", "spiffe://bar.foo"},
+			ips:  []string{"1.2.3.4"},
+			usages: []cmapi.KeyUsage{
+				cmapi.UsageDigitalSignature,
+				cmapi.UsageKeyEncipherment,
+				cmapi.UsageClientAuth,
+				cmapi.UsageServerAuth,
+			},
+			expErr: true,
+		},
+		"if multiple URI names exist, emails, and allowed usages, should error": {
+			uris:   []string{"spiffe://foo.bar", "spiffe://bar.foo"},
+			emails: []string{"hello@example.com"},
+			usages: []cmapi.KeyUsage{
+				cmapi.UsageDigitalSignature,
+				cmapi.UsageKeyEncipherment,
+				cmapi.UsageClientAuth,
+				cmapi.UsageServerAuth,
+			},
+			expErr: true,
+		},
+		"if multiple URI names exist, emails, dns, ips, and allowed usages, should error": {
+			uris:   []string{"spiffe://foo.bar", "spiffe://bar.foo"},
+			dns:    []string{"foo.bar"},
+			ips:    []string{"1.2.3.4"},
+			emails: []string{"hello@example.com"},
+			usages: []cmapi.KeyUsage{
+				cmapi.UsageDigitalSignature,
+				cmapi.UsageKeyEncipherment,
+				cmapi.UsageClientAuth,
+				cmapi.UsageServerAuth,
+			},
+			expErr: true,
+		},
+		"if multiple URI names exist, and subset allowed usages, shouldn't error": {
+			uris: []string{"spiffe://foo.bar", "spiffe://bar.foo"},
+			usages: []cmapi.KeyUsage{
+				cmapi.UsageDigitalSignature,
+				cmapi.UsageServerAuth,
+			},
+			expErr: false,
+		},
+		"if multiple URI names exist, with disallowed usages, should error": {
+			uris: []string{"spiffe://foo.bar", "spiffe://bar.foo"},
+			usages: []cmapi.KeyUsage{
+				cmapi.UsageDigitalSignature,
+				cmapi.UsageKeyEncipherment,
+				cmapi.UsageClientAuth,
+				cmapi.UsageServerAuth,
+				cmapi.UsageCertSign,
+			},
+			expErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			csr, err := pkiutil.GenerateCSR(&cmapi.Certificate{
+				Spec: cmapi.CertificateSpec{
+					EmailAddresses: test.emails,
+					DNSNames:       test.dns,
+					IPAddresses:    test.ips,
+					Usages:         test.usages,
+					URIs:           test.uris,
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Re encode/parse csr to simulate real x509 csr parsing
+			csrDER, err := pkiutil.EncodeCSR(csr, sk)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			csr, err = x509.ParseCertificateRequest(csrDER)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = ValidateCSRExtentions(csr)
+			if (err != nil) != test.expErr {
+				t.Errorf("unexpected error, exp=%t got=%v",
+					test.expErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateExtendedKeyUsageExtension(t *testing.T) {
+	type testcase struct {
+		usages []x509.ExtKeyUsage
+		expErr bool
+	}
+
+	var (
+		tests []testcase
+		// Generate powerset of both disallowed and allowed usages
+		disallowedExtUsagesPowerset = powerset(disallowedX509ExtKeyUsages)
+		allowedExtUsagesPowerset    = append(powerset(allowedX509ExtKeyUsages), nil)
+	)
+
+	// Expect all sets with any disallowed usages to always fail
+	for _, disallowed := range disallowedExtUsagesPowerset {
+		for _, allowed := range allowedExtUsagesPowerset {
+			var extUsages []x509.ExtKeyUsage
+			for _, usage := range append(disallowed, allowed...) {
+				extUsages = append(extUsages, usage.(x509.ExtKeyUsage))
+			}
+
+			tests = append(tests, testcase{extUsages, true})
+		}
+	}
+
+	for _, allowed := range allowedExtUsagesPowerset {
+		var extUsages []x509.ExtKeyUsage
+		for _, usage := range allowed {
+			extUsages = append(extUsages, usage.(x509.ExtKeyUsage))
+		}
+
+		tests = append(tests, testcase{extUsages, true})
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("ext usages [%v] expErr=%t", test.usages, test.expErr), func(t *testing.T) {
+			var ids []asn1.ObjectIdentifier
+			for _, usage := range test.usages {
+				id, ok := pkiutil.OIDFromExtKeyUsage(usage)
+				if !ok {
+					t.Fatalf("%v", usage)
+				}
+
+				ids = append(ids, id)
+			}
+
+			val, err := asn1.Marshal(ids)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			extension := pkix.Extension{
+				Id:    oidExtensionKeyUsage,
+				Value: val,
+			}
+
+			err = validateExtendedKeyUsageExtension(extension)
+			if (err != nil) != test.expErr {
+				t.Errorf("unexpected error, exp=%t got=%v (%v)", test.expErr, err, test.usages)
+			}
+		})
+	}
+}
+
+func TestValidateKeyUsageExtension(t *testing.T) {
+	type testcase struct {
+		usage  x509.KeyUsage
+		expErr bool
+	}
+
+	var (
+		tests []testcase
+		// Generate powerset of both disallowed and allowed usages
+		disallowedUsagesPowerset = powerset(disallowedX509KeyUsages)
+		allowedUsagesPowerset    = append(powerset(allowedX509KeyUsages), nil)
+	)
+
+	// Expect all sets with any disallowed usages to always fail
+	for _, disallowed := range disallowedUsagesPowerset {
+		for _, allowed := range allowedUsagesPowerset {
+			var ku x509.KeyUsage
+			for _, use := range append(disallowed, allowed...) {
+				ku |= use.(x509.KeyUsage)
+			}
+
+			tests = append(tests, testcase{ku, true})
+		}
+	}
+
+	// Expect all sets with only allowed or empty usages to always pass
+	for _, allowed := range allowedUsagesPowerset {
+		var ku x509.KeyUsage
+		for _, use := range allowed {
+			ku |= use.(x509.KeyUsage)
+		}
+
+		tests = append(tests, testcase{ku, false})
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("usage [%v] expErr=%t", test.usage, test.expErr), func(t *testing.T) {
+			ext, err := buildASN1KeyUsageRequest(test.usage)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = validateKeyUsageExtension(ext.Value)
+			if (err != nil) != test.expErr {
+				t.Errorf("unexpected error, exp=%t got=%v (%v)", test.expErr, err, test.usage)
+			}
+		})
+	}
+}
+
+// Adapted from https://github.com/mxschmitt/golang-combinations
+func powerset(set []interface{}) (subsets [][]interface{}) {
+	length := uint(len(set))
+
+	// Go through all possible combinations of objects
+	// from 1 (only first object in subset) to 2^length (all objects in subset)
+	//math.Pow(
+	for subsetBits := 1; subsetBits < (1 << length); subsetBits++ {
+		var subset []interface{}
+
+		for object := uint(0); object < length; object++ {
+			// checks if object is contained in subset
+			// by checking if bit 'object' is set in subsetBits
+			if (subsetBits>>object)&1 == 1 {
+				// add object to subset
+				subset = append(subset, set[object])
+			}
+		}
+		// add subset to subsets
+		subsets = append(subsets, subset)
+	}
+
+	return subsets
+}
+
+// Copied from x509.go
+func reverseBitsInAByte(in byte) byte {
+	b1 := in>>4 | in<<4
+	b2 := b1>>2&0x33 | b1<<2&0xcc
+	b3 := b2>>1&0x55 | b2<<1&0xaa
+	return b3
+}
+
+// Adapted from x509.go
+func buildASN1KeyUsageRequest(usage x509.KeyUsage) (pkix.Extension, error) {
+	OIDExtensionKeyUsage := pkix.Extension{
+		Id: oidExtensionKeyUsage,
+	}
+	var a [2]byte
+	a[0] = reverseBitsInAByte(byte(usage))
+	a[1] = reverseBitsInAByte(byte(usage >> 8))
+
+	l := 1
+	if a[1] != 0 {
+		l = 2
+	}
+
+	bitString := a[:l]
+	var err error
+	OIDExtensionKeyUsage.Value, err = asn1.Marshal(asn1.BitString{Bytes: bitString, BitLength: asn1BitLength(bitString)})
+	if err != nil {
+		return pkix.Extension{}, err
+	}
+
+	return OIDExtensionKeyUsage, nil
+}
+
+// asn1BitLength returns the bit-length of bitString by considering the
+// most-significant bit in a byte to be the "first" bit. This convention
+// matches ASN.1, but differs from almost everything else.
+func asn1BitLength(bitString []byte) int {
+	bitLen := len(bitString) * 8
+
+	for i := range bitString {
+		b := bitString[len(bitString)-i-1]
+
+		for bit := uint(0); bit < 8; bit++ {
+			if (b>>bit)&1 == 1 {
+				return bitLen
+			}
+			bitLen--
+		}
+	}
+
+	return 0
+}


### PR DESCRIPTION
This PR introduces more in depth CSR extension validation, ensuring CSR may only contain:
- Valid URI SANs
- Server and Client Auth extended key usages
- Digital Signature and Key Encipherment key usages