### PR TITLE
Allow the TrustDomain to be set.

### DIFF
--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -75,7 +75,8 @@ type TLSOptions struct {
 	ServingAddress             string
 	ServingCertificateDuration time.Duration
 
-	ClusterID string
+	ClusterID   string
+	TrustDomain string
 }
 
 type KubeOptions struct {
@@ -106,6 +107,11 @@ func (o *Options) Complete() error {
 	log := klogr.New()
 	flag.Set("v", o.logLevel)
 	o.Logr = log
+
+	// Set the trust domain before the Auther and tls Provider are created to
+	// ensure the trust domain is set correctly before being used to
+	// authenticate requests
+	spiffe.SetTrustDomain(o.TLSOptions.TrustDomain)
 
 	var err error
 	o.RestConfig, err = o.kubeConfigFlags.ToRESTConfig()
@@ -199,6 +205,10 @@ func (t *TLSOptions) addFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&t.ClusterID, "cluster-id", "Kubernetes",
 		"The ID of the istio cluster to verify.")
+
+	fs.StringVar(&t.TrustDomain,
+		"trust-domain", "cluster.local",
+		"The Istio cluster's trust domain.")
 }
 
 func (c *CertManagerOptions) addFlags(fs *pflag.FlagSet) {

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -43,6 +43,7 @@ spec:
           - "--issuer-group={{.Values.certificate.group}}"
           - "--issuer-kind={{.Values.certificate.kind}}"
           - "--issuer-name={{.Values.certificate.name}}"
+          - "--trust-domain={{.Values.agent.trustDomain}}"
           - "--max-client-certificate-duration={{.Values.certificate.maxDuration}}"
           - "--preserve-certificate-requests={{.Values.certificate.preserveCertificateRequests}}"
 

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -27,6 +27,9 @@ agent:
   # -- The istio cluster ID to verify incoming CSRs.
   clusterID: "Kubernetes"
 
+  # -- The Istio cluster's trust domain.
+  trustDomain: "cluster.local"
+
   # -- Container address to serve istio-csr gRPC service.
   servingAddress: 0.0.0.0
   # -- Container port to serve istio-csr gRPC service.

--- a/hack/demo/values.yaml
+++ b/hack/demo/values.yaml
@@ -13,6 +13,8 @@ service:
 agent:
   logLevel: 5
 
+  trustDomain: foo.bar
+
   servingAddress: 0.0.0.0
   servingPort: 6443
 

--- a/hack/istio-config-1.7.6.yaml
+++ b/hack/istio-config-1.7.6.yaml
@@ -5,8 +5,21 @@ metadata:
 spec:
   profile: "demo"
   hub: gcr.io/istio-release
+  meshConfig:
+    # Change the following lines to configure the trust domain of the Istio
+    # cluster. There are 3 places that need to be updated in versions of Istio
+    # prior to 1.8.0:
+    # - meshConfig.trustDomain
+    # - values.global.trustDomain
+    # - meshConfig.defaultConfig.proxyMetadata.TRUST_DOMAIN (which creates an
+    # env var in every istio-proxy deployment called TRUST_DOMAIN)
+    trustDomain: foo.bar
+    defaultConfig:
+      proxyMetadata:
+        TRUST_DOMAIN: foo.bar
   values:
     global:
+      trustDomain: foo.bar
       # Change certificate provider to cert-manager istio agent for istio agent
       caAddress: cert-manager-istio-csr.cert-manager.svc:443
   components:

--- a/hack/istio-config-1.8.2.yaml
+++ b/hack/istio-config-1.8.2.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   profile: "demo"
   hub: gcr.io/istio-release
+  meshConfig:
+    # Change the following line to configure the trust domain of the Istio cluster.
+    trustDomain: foo.bar
   values:
     global:
       # Change certificate provider to cert-manager istio agent for istio agent

--- a/hack/istio-config-1.9.1.yaml
+++ b/hack/istio-config-1.9.1.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   profile: "demo"
   hub: gcr.io/istio-release
+  meshConfig:
+    # Change the following line to configure the trust domain of the Istio cluster.
+    trustDomain: foo.bar
   values:
     global:
       # Change certificate provider to cert-manager istio agent for istio agent

--- a/test/e2e/suite/request/request.go
+++ b/test/e2e/suite/request/request.go
@@ -111,7 +111,7 @@ var _ = framework.CasesDescribe("Request Authentication", func() {
 
 	It("should reject a request with a bad service account token", func() {
 		csr, err := gen.CSR(
-			gen.SetCSRIdentities([]string{fmt.Sprintf("spiffe://cluster.local/ns/%s/sa/%s", namespace, saName)}),
+			gen.SetCSRIdentities([]string{fmt.Sprintf("spiffe://foo.bar/ns/%s/sa/%s", namespace, saName)}),
 		)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = client.CSRSign(context.TODO(), "", csr, "bad token", 100)
@@ -124,7 +124,7 @@ var _ = framework.CasesDescribe("Request Authentication", func() {
 	})
 
 	It("should reject a request with dns", func() {
-		id := fmt.Sprintf("spiffe://cluster.local/ns/%s/sa/%s", namespace, saName)
+		id := fmt.Sprintf("spiffe://foo.bar/ns/%s/sa/%s", namespace, saName)
 		csr, err := gen.CSR(
 			gen.SetCSRIdentities([]string{id}),
 			gen.SetCSRDNS([]string{"example.com", "jetstack.io"}),
@@ -136,7 +136,7 @@ var _ = framework.CasesDescribe("Request Authentication", func() {
 	})
 
 	It("should reject a request with ips", func() {
-		id := fmt.Sprintf("spiffe://cluster.local/ns/%s/sa/%s", namespace, saName)
+		id := fmt.Sprintf("spiffe://foo.bar/ns/%s/sa/%s", namespace, saName)
 		csr, err := gen.CSR(
 			gen.SetCSRIdentities([]string{id}),
 			gen.SetCSRIPs([]string{"8.8.8.8"}),
@@ -148,7 +148,7 @@ var _ = framework.CasesDescribe("Request Authentication", func() {
 	})
 
 	It("should reject a request with emails", func() {
-		id := fmt.Sprintf("spiffe://cluster.local/ns/%s/sa/%s", namespace, saName)
+		id := fmt.Sprintf("spiffe://foo.bar/ns/%s/sa/%s", namespace, saName)
 		csr, err := gen.CSR(
 			gen.SetCSRIdentities([]string{id}),
 			gen.SetCSREmails([]string{"joshua.vanleeuwen@jetstack.io"}),
@@ -160,7 +160,7 @@ var _ = framework.CasesDescribe("Request Authentication", func() {
 	})
 
 	It("should reject a request with emails", func() {
-		id := fmt.Sprintf("spiffe://cluster.local/ns/%s/sa/%s", namespace, saName)
+		id := fmt.Sprintf("spiffe://foo.bar/ns/%s/sa/%s", namespace, saName)
 		csr, err := gen.CSR(
 			gen.SetCSRIdentities([]string{id}),
 			gen.SetCSREmails([]string{"joshua.vanleeuwen@jetstack.io"}),
@@ -182,7 +182,7 @@ var _ = framework.CasesDescribe("Request Authentication", func() {
 	})
 
 	It("should reject a request with more ids", func() {
-		id := fmt.Sprintf("spiffe://cluster.local/ns/%s/sa/%s", namespace, saName)
+		id := fmt.Sprintf("spiffe://foo.bar/ns/%s/sa/%s", namespace, saName)
 		csr, err := gen.CSR(
 			gen.SetCSRIdentities([]string{id, "spiffe://bar"}),
 		)
@@ -195,7 +195,7 @@ var _ = framework.CasesDescribe("Request Authentication", func() {
 	It("should correctly return a valid signed certificate on a correct request", func() {
 		By("correctly request a valid certificate")
 
-		id := fmt.Sprintf("spiffe://cluster.local/ns/%s/sa/%s", namespace, saName)
+		id := fmt.Sprintf("spiffe://foo.bar/ns/%s/sa/%s", namespace, saName)
 		csr, err := gen.CSR(
 			gen.SetCSRIdentities([]string{id}),
 		)


### PR DESCRIPTION
This PR is meant to add support for custom trust domains to Istio CSR. It sets the domain in the SPIFFE library allowing for certificates with a the trust domain to be signed.

The tests were updated to specify a custom trust domain (`foo.bar`). LMK if there's a better way to test a change like this.

The Helm chart was updated as well, a new `value` was added: `trustDomain`.