### PR TITLE
Added the ability to set dns names in the istio-csr certificate.

### DIFF
--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -74,6 +74,7 @@ type TLSOptions struct {
 	RootCAConfigMapName        string
 	ServingAddress             string
 	ServingCertificateDuration time.Duration
+	DNSNames                   []string
 
 	ClusterID   string
 	TrustDomain string
@@ -192,6 +193,10 @@ func (t *TLSOptions) addFlags(fs *pflag.FlagSet) {
 		"serving-certificate-duration", "t", time.Hour*24,
 		"Certificate duration of serving certificates. Will be renewed after 2/3 of "+
 			"the duration.")
+
+	fs.StringSliceVar(&t.DNSNames,
+		"dns-names", []string{"cert-manager-istio-csr.cert-manager.svc"},
+		"A list of names used to route requests to Istio CSR.")
 
 	fs.StringVar(&t.RootCACertFile,
 		"root-ca-file", "",

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -74,7 +74,7 @@ type TLSOptions struct {
 	RootCAConfigMapName        string
 	ServingAddress             string
 	ServingCertificateDuration time.Duration
-	DNSNames                   []string
+	ServingCertificateDNSNames []string
 
 	ClusterID   string
 	TrustDomain string
@@ -108,6 +108,12 @@ func (o *Options) Complete() error {
 	log := klogr.New()
 	flag.Set("v", o.logLevel)
 	o.Logr = log
+
+	// Ensure there is at least one DNS name to set in the serving certificate
+	// to ensure clients can properly verify the serving certificate
+	if len(o.TLSOptions.ServingCertificateDNSNames) == 0 {
+		return fmt.Errorf("the list of DNS names to add to the serving certificate is empty")
+	}
 
 	// Set the trust domain before the Auther and tls Provider are created to
 	// ensure the trust domain is set correctly before being used to
@@ -194,9 +200,10 @@ func (t *TLSOptions) addFlags(fs *pflag.FlagSet) {
 		"Certificate duration of serving certificates. Will be renewed after 2/3 of "+
 			"the duration.")
 
-	fs.StringSliceVar(&t.DNSNames,
-		"dns-names", []string{"cert-manager-istio-csr.cert-manager.svc"},
-		"A list of names used to route requests to Istio CSR.")
+	fs.StringSliceVar(&t.ServingCertificateDNSNames,
+		"serving-certificate-dns-names", []string{"cert-manager-istio-csr.cert-manager.svc"},
+		"A list of DNS names to request for the server's serving certificate which will be "+
+			"presented to istio-agents.")
 
 	fs.StringVar(&t.RootCACertFile,
 		"root-ca-file", "",

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -37,6 +37,10 @@ spec:
 
           - "--serving-address={{.Values.agent.servingAddress}}:{{.Values.agent.servingPort}}"
           - "--serving-certificate-duration={{.Values.agent.certificateDuration}}"
+        {{- range .Values.agent.certificateDNSNames }}
+          - "--serving-certificate-dns-names={{ . }}"
+        {{- end  }}
+
           - "--root-ca-configmap-name={{.Values.agent.rootCAConfigMapName}}"
 
           - "--certificate-namespace={{.Values.certificate.namespace}}"
@@ -46,10 +50,6 @@ spec:
           - "--trust-domain={{.Values.agent.trustDomain}}"
           - "--max-client-certificate-duration={{.Values.certificate.maxDuration}}"
           - "--preserve-certificate-requests={{.Values.certificate.preserveCertificateRequests}}"
-
-        {{- range .Values.service.dnsNames }}
-          - "--dns-names={{ . }}"
-        {{- end  }}
 
         {{- if .Values.certificate.rootCA }}
           - "--root-ca-file=/etc/cert-manager-istio-csr/ca.pem"

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -47,6 +47,10 @@ spec:
           - "--max-client-certificate-duration={{.Values.certificate.maxDuration}}"
           - "--preserve-certificate-requests={{.Values.certificate.preserveCertificateRequests}}"
 
+        {{- range .Values.service.dnsNames }}
+          - "--dns-names={{ . }}"
+        {{- end  }}
+
         {{- if .Values.certificate.rootCA }}
           - "--root-ca-file=/etc/cert-manager-istio-csr/ca.pem"
 

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -14,6 +14,9 @@ service:
   type: ClusterIP
   # -- Service port to expose istio-csr gRPC service.
   port: 443
+  # -- The names used when sending requests to istio-csr
+  dnsNames:
+  - cert-manager-istio-csr.cert-manager.svc
 
 agent:
   # -- Verbosity of istio-csr logging.

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -14,9 +14,6 @@ service:
   type: ClusterIP
   # -- Service port to expose istio-csr gRPC service.
   port: 443
-  # -- The names used when sending requests to istio-csr
-  dnsNames:
-  - cert-manager-istio-csr.cert-manager.svc
 
 agent:
   # -- Verbosity of istio-csr logging.
@@ -43,6 +40,12 @@ agent:
 
   # -- Requested duration of gRPC serving certificate. Will be automatically renewed.
   certificateDuration: 24h
+
+  # -- The DNS names to request for the server's serving certificate which is
+  # presented to istio-agents. istio-agents must route to istio-csr using one
+  # of these DNS names.
+  certificateDNSNames:
+  - cert-manager-istio-csr.cert-manager.svc
 
 certificate:
   # -- Namespace to create CertificateRequests from incoming gRPC CSRs.

--- a/hack/demo/values.yaml
+++ b/hack/demo/values.yaml
@@ -9,11 +9,6 @@ service:
   port: 443
   type: NodePort
   nodePort: 30443
-  dnsNames:
-  # Name used by the e2e client
-  - istio-csr.cert-manager.svc
-  # Name used within the demo cluster
-  - cert-manager-istio-csr.cert-manager.svc
 
 agent:
   logLevel: 5
@@ -24,6 +19,12 @@ agent:
   servingPort: 6443
 
   certificateDuration: 20s
+  certificateDNSNames:
+  # Name used by the e2e client
+  - istio-csr.cert-manager.svc
+  # Name used within the demo cluster
+  - cert-manager-istio-csr.cert-manager.svc
+
   rootCAConfigMapName: istio-ca-root-cert
 
 certificate:

--- a/hack/demo/values.yaml
+++ b/hack/demo/values.yaml
@@ -9,6 +9,11 @@ service:
   port: 443
   type: NodePort
   nodePort: 30443
+  dnsNames:
+  # Name used by the e2e client
+  - istio-csr.cert-manager.svc
+  # Name used within the demo cluster
+  - cert-manager-istio-csr.cert-manager.svc
 
 agent:
   logLevel: 5

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -72,7 +72,7 @@ func NewProvider(ctx context.Context, log logr.Logger, tlsOptions *options.TLSOp
 		log: log.WithName("serving_certificate"),
 
 		servingCertificateTTL: tlsOptions.ServingCertificateDuration,
-		dnsNames:              tlsOptions.DNSNames,
+		dnsNames:              tlsOptions.ServingCertificateDNSNames,
 		preserveCRs:           cmOptions.PreserveCRs,
 		customRootCA:          len(tlsOptions.RootCACertFile) > 0,
 		client:                kubeOptions.CMClient,

--- a/test/e2e/suite/internal/client/client.go
+++ b/test/e2e/suite/internal/client/client.go
@@ -135,7 +135,7 @@ func (c *certmanagerClient) getTLSDialOption() (grpc.DialOption, error) {
 
 	// For debugging on localhost (with port forward)
 	if strings.Contains(c.caEndpoint, "localhost") {
-		config.ServerName = "cert-manager-istio-csr.cert-manager.svc"
+		config.ServerName = "istio-csr.cert-manager.svc"
 	}
 
 	transportCreds := credentials.NewTLS(&config)

--- a/test/e2e/suite/request/request.go
+++ b/test/e2e/suite/request/request.go
@@ -98,7 +98,7 @@ var _ = framework.CasesDescribe("Request Authentication", func() {
 
 		saTokenBytes, ok := secret.Data[corev1.ServiceAccountTokenKey]
 		if !ok {
-			Expect(secret, "epected Service Account token present in secret").NotTo(HaveOccurred())
+			Expect(secret, "expected Service Account token present in secret").NotTo(HaveOccurred())
 		}
 		saToken = string(saTokenBytes)
 	})


### PR DESCRIPTION
I've added a `dns-names` argument that can be used to set the DNS names is istio-csr's certificate it presents to the `istio-agent`. This allows access to `istio-csr` from outside of a Kubernetes cluster (ie. an `istio-proxy` running in a DC).

The tests were updated so that the istio-csr client in the e2e test folder uses the name `istio-csr.cert-manager.svc` and the istio-agents in the cluster use the default name `cert-manager-istio-csr.cert-manager.svc`.

The Helm chart has been updated to set the arguments in the deployment with a list of dnsNames.