### PR TITLE
Exit error if we lose leader election, fix election ID

### DIFF
--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -102,7 +102,7 @@ func NewProvider(ctx context.Context, log logr.Logger, tlsOptions *options.TLSOp
 			renewalTime := (2 * p.servingCertificateTTL) / 3
 			timer := time.NewTimer(renewalTime)
 
-			p.log.Info("renewing serving certificate", "renewal-time", renewalTime)
+			p.log.Info("renewing serving certificate", "renewal-time", time.Now().Add(renewalTime))
 
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
Signed-off-by: joshvanl <vleeuwenjoshua@gmail.com>

This PR fixes a bug where is the leader election is lost because of a transient network error or similar, the istio-csr becomes unready. To fix this issue, istio-csr will exit error, which will cause either: 1. another istio-csr to assume the leader, or 2. istio-csr restarts and assumes the leader again.

Exiting the program is the [canonical way](https://github.com/kubernetes-sigs/controller-runtime/blob/fbf50b04fe17b0f091430d22557245d2aedabfd4/pkg/manager/manager.go#L83) for handling losing the leader election. 

Adding a specific event broadcaster is used to prevent a permissions error where istio-csr would create an event in the default namespace when losing/failing to renew a lease. By passing a custom recorder, we force the event to be created in the istio-system namespace which istio-csr has permissions for.

/assign @jakexks 
fixes #20 #36
