### PR TITLE
Change default certificate settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ and control plane components to be secured using
 and intra cluster, will be signed, delivered and renewed using [cert-manager
 issuers](https://cert-manager.io/docs/concepts/issuer).
 
-Currently supports istio versions v1.7+
+⚠️ Currently supports istio versions v1.7+
+⚠️ Currently supports cert-manager versions v1.3+
 
 ---
 

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -145,7 +145,7 @@ func (o *Options) addTLSFlags(fs *pflag.FlagSet) {
 			"cert-manager issuer will be used.")
 
 	fs.DurationVarP(&o.TLS.ServingCertificateDuration,
-		"serving-certificate-duration", "t", time.Hour*24,
+		"serving-certificate-duration", "t", time.Hour,
 		"Certificate duration of serving certificates. Will be renewed after 2/3 of "+
 			"the duration.")
 
@@ -182,7 +182,7 @@ func (o *Options) addServerFlags(fs *pflag.FlagSet) {
 		"Address to serve certificates gRPC service.")
 
 	fs.DurationVarP(&o.Server.MaximumClientCertificateDuration,
-		"max-client-certificate-duration", "m", time.Hour*24,
+		"max-client-certificate-duration", "m", time.Hour,
 		"Maximum duration a client certificate can be requested and valid for. Will "+
 			"override with this value if the requested duration is larger")
 

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -144,6 +144,9 @@ func (o *Options) addTLSFlags(fs *pflag.FlagSet) {
 			"trust for TLS in the mesh. If empty, the CA returned from the "+
 			"cert-manager issuer will be used.")
 
+	// Here we use a duration of 1 hour by default, based on NIST 800-204A
+	// recommendations (SM-DR13).
+	// https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf
 	fs.DurationVarP(&o.TLS.ServingCertificateDuration,
 		"serving-certificate-duration", "t", time.Hour,
 		"Certificate duration of serving certificates. Will be renewed after 2/3 of "+

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -31,11 +31,11 @@ A Helm chart for istio-csr
 | app.readinessProbe.path | string | `"/readyz"` | Path to expose istio-csr HTTP readiness probe on default network interface. |
 | app.readinessProbe.port | int | `6060` | Container port to expose istio-csr HTTP readiness probe on default network interface. |
 | app.server.clusterID | string | `"Kubernetes"` | The istio cluster ID to verify incoming CSRs. |
-| app.server.maxCertificateDuration | string | `"1h"` | Maximum validity duration that can be requested for a certificate. istio-csr will request a duration of the smaller of this value, and that of the incoming gRPC CSR. |
+| app.server.maxCertificateDuration | string | `"1h"` | Maximum validity duration that can be requested for a certificate. istio-csr will request a duration of the smaller of this value, and that of the incoming gRPC CSR. Based on NIST 800-204A recommendations (SM-DR13). https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf |
 | app.server.serving.address | string | `"0.0.0.0"` | Container address to serve istio-csr gRPC service. |
 | app.server.serving.port | int | `6443` | Container port to serve istio-csr gRPC service. |
 | app.tls.certificateDNSNames | list | `["cert-manager-istio-csr.cert-manager.svc"]` | The DNS names to request for the server's serving certificate which is presented to istio-agents. istio-agents must route to istio-csr using one of these DNS names. |
-| app.tls.certificateDuration | string | `"1h"` | Requested duration of gRPC serving certificate. Will be automatically renewed. |
+| app.tls.certificateDuration | string | `"1h"` | Requested duration of gRPC serving certificate. Will be automatically renewed. Based on NIST 800-204A recommendations (SM-DR13). https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf cert-manager does not allow a duration on Certificates less than 1 hour. |
 | app.tls.rootCAFile | string | `nil` | An optional file location to a PEM encoded root CA that the root CA ConfigMap in all namespaces will be populated with. If empty, the CA returned from cert-manager for the serving certificate will be used. |
 | app.tls.trustDomain | string | `"cluster.local"` | The Istio cluster's trust domain. |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on Deployment. |

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -31,11 +31,11 @@ A Helm chart for istio-csr
 | app.readinessProbe.path | string | `"/readyz"` | Path to expose istio-csr HTTP readiness probe on default network interface. |
 | app.readinessProbe.port | int | `6060` | Container port to expose istio-csr HTTP readiness probe on default network interface. |
 | app.server.clusterID | string | `"Kubernetes"` | The istio cluster ID to verify incoming CSRs. |
-| app.server.maxCertificateDuration | string | `"24h"` | Maximum validity duration that can be requested for a certificate. istio-csr will request a duration of the smaller of this value, and that of the incoming gRPC CSR. |
+| app.server.maxCertificateDuration | string | `"1h"` | Maximum validity duration that can be requested for a certificate. istio-csr will request a duration of the smaller of this value, and that of the incoming gRPC CSR. |
 | app.server.serving.address | string | `"0.0.0.0"` | Container address to serve istio-csr gRPC service. |
 | app.server.serving.port | int | `6443` | Container port to serve istio-csr gRPC service. |
 | app.tls.certificateDNSNames | list | `["cert-manager-istio-csr.cert-manager.svc"]` | The DNS names to request for the server's serving certificate which is presented to istio-agents. istio-agents must route to istio-csr using one of these DNS names. |
-| app.tls.certificateDuration | string | `"24h"` | Requested duration of gRPC serving certificate. Will be automatically renewed. |
+| app.tls.certificateDuration | string | `"1h"` | Requested duration of gRPC serving certificate. Will be automatically renewed. |
 | app.tls.rootCAFile | string | `nil` | An optional file location to a PEM encoded root CA that the root CA ConfigMap in all namespaces will be populated with. If empty, the CA returned from cert-manager for the serving certificate will be used. |
 | app.tls.trustDomain | string | `"cluster.local"` | The Istio cluster's trust domain. |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on Deployment. |

--- a/deploy/charts/istio-csr/templates/certificate.yaml
+++ b/deploy/charts/istio-csr/templates/certificate.yaml
@@ -9,6 +9,10 @@ spec:
   uris:
     - spiffe://cluster.local/ns/istio-system/sa/istiod-service-account
   secretName: istiod-tls
+  # Here we use a duration of 1 hour by default based on NIST 800-204A
+  # recommendations (SM-DR13).
+  # https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf
+  # cert-manager does not allow a duration on Certificates of less that 1 hour.
   duration: 1h
   renewBefore: 30m
   privateKey:

--- a/deploy/charts/istio-csr/templates/certificate.yaml
+++ b/deploy/charts/istio-csr/templates/certificate.yaml
@@ -4,13 +4,18 @@ metadata:
   name: istiod
   namespace: istio-system
 spec:
-  duration: 24h
-  renewBefore: 12h
-  secretName: istiod-tls
   dnsNames:
   - istiod.istio-system.svc
   uris:
     - spiffe://cluster.local/ns/istio-system/sa/istiod-service-account
+  secretName: istiod-tls
+  duration: 1h
+  renewBefore: 30m
+  privateKey:
+    rotationPolicy: Always
+    algorithm: RSA
+    size: 2048
+  revisionHistoryLimit: 1
   issuerRef:
     name: {{ .Values.app.certmanager.issuer.name }}
     kind: {{ .Values.app.certmanager.issuer.kind }}

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -55,7 +55,7 @@ app:
     certificateDNSNames:
     - cert-manager-istio-csr.cert-manager.svc
     # -- Requested duration of gRPC serving certificate. Will be automatically renewed.
-    certificateDuration: 24h
+    certificateDuration: 1h
 
   server:
     # -- The istio cluster ID to verify incoming CSRs.
@@ -63,7 +63,7 @@ app:
     # -- Maximum validity duration that can be requested for a certificate.
     # istio-csr will request a duration of the smaller of this value, and that of
     # the incoming gRPC CSR.
-    maxCertificateDuration: 24h
+    maxCertificateDuration: 1h
     serving:
       # -- Container address to serve istio-csr gRPC service.
       address: 0.0.0.0

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -55,6 +55,9 @@ app:
     certificateDNSNames:
     - cert-manager-istio-csr.cert-manager.svc
     # -- Requested duration of gRPC serving certificate. Will be automatically renewed.
+    # Based on NIST 800-204A recommendations (SM-DR13).
+    # https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf
+    # cert-manager does not allow a duration on Certificates less than 1 hour.
     certificateDuration: 1h
 
   server:
@@ -63,6 +66,8 @@ app:
     # -- Maximum validity duration that can be requested for a certificate.
     # istio-csr will request a duration of the smaller of this value, and that of
     # the incoming gRPC CSR.
+    # Based on NIST 800-204A recommendations (SM-DR13).
+    # https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf
     maxCertificateDuration: 1h
     serving:
       # -- Container address to serve istio-csr gRPC service.


### PR DESCRIPTION
This PR changes all the default certificate settings to be a 1 hour duration, in-line with the [NIST 800-204A](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf) recommendations (SM-DR13). 

This PR also changed the `istiod` Certificate to have a hardcoded 1 hour certificate. Hardcoded as cert-manager Certificates may not have a duration of less than 1 hour.

Also bumps the cert-manager e2e installation to v1.3 as the Certificate now includes the `revisionHistoryLimit` field. The README has been updated to reflect this new minimum required version. A new minor release (v0.2) is required for this after merging when publishing.

/assign @jakexks 
/cc @SpectralHiss