### PR TITLE
Add metrics

### DIFF
--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -67,9 +67,9 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("error creating kubernetes client: %s", err.Error())
 			}
 
-			log := opts.Logr.WithName("manager")
+			mlog := opts.Logr.WithName("manager")
 			eventBroadcaster := record.NewBroadcaster()
-			eventBroadcaster.StartLogging(func(format string, args ...interface{}) { log.V(3).Info(fmt.Sprintf(format, args...)) })
+			eventBroadcaster.StartLogging(func(format string, args ...interface{}) { mlog.V(3).Info(fmt.Sprintf(format, args...)) })
 			eventBroadcaster.StartRecordingToSink(&clientv1.EventSinkImpl{Interface: cl.CoreV1().Events("istio-system")})
 
 			mgr, err := ctrl.NewManager(opts.RestConfig, ctrl.Options{
@@ -81,7 +81,8 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				LeaderElectionReleaseOnCancel: true,
 				ReadinessEndpointName:         opts.ReadyzPath,
 				HealthProbeBindAddress:        fmt.Sprintf("0.0.0.0:%d", opts.ReadyzPort),
-				Logger:                        log,
+				MetricsBindAddress:            fmt.Sprintf("0.0.0.0:%d", opts.MetricsPort),
+				Logger:                        mlog,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to create manager: %w", err)

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -47,6 +47,10 @@ type Options struct {
 	// ReadyzPath if the HTTP path used to expose Prometheus metrics.
 	ReadyzPath string
 
+	// MetricsPort is the port for exposing Prometheus metrics on 0.0.0.0 on the
+	// path '/metrics'.
+	MetricsPort int
+
 	// Logr is the shared base logger.
 	Logr logr.Logger
 
@@ -131,6 +135,10 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.ReadyzPath,
 		"readiness-probe-path", "/readyz",
 		"HTTP path to expose the readiness probe server.")
+
+	fs.IntVar(&o.MetricsPort,
+		"metrics-port", 9402,
+		"Port to expose Prometheus metrics on 0.0.0.0 on path '/metrics'.")
 }
 
 func (o *Options) addTLSFlags(fs *pflag.FlagSet) {

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -29,6 +29,10 @@ A Helm chart for istio-csr
 | app.controller.rootCAConfigMapName | string | `"istio-ca-root-cert"` | Name of ConfigMap that should contain the root CA in all namespaces. |
 | app.logLevel | int | `1` | Verbosity of istio-csr logging. |
 | app.metrics.port | int | `9402` | Port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'. |
+| app.metrics.service | object | `{"enabled":true,"servicemonitor":{"enabled":false,"interval":"10s","labels":{},"prometheusInstance":"default","scrapeTimeout":"5s"},"type":"ClusterIP"}` | Service to expose metrics endpoint. |
+| app.metrics.service.enabled | bool | `true` | Create a Service resource to expose metrics endpoint. |
+| app.metrics.service.servicemonitor | object | `{"enabled":false,"interval":"10s","labels":{},"prometheusInstance":"default","scrapeTimeout":"5s"}` | ServiceMonitor resource for this Service. |
+| app.metrics.service.type | string | `"ClusterIP"` | Service type to expose metrics. |
 | app.readinessProbe.path | string | `"/readyz"` | Path to expose istio-csr HTTP readiness probe on default network interface. |
 | app.readinessProbe.port | int | `6060` | Container port to expose istio-csr HTTP readiness probe on default network interface. |
 | app.server.clusterID | string | `"Kubernetes"` | The istio cluster ID to verify incoming CSRs. |

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -28,6 +28,7 @@ A Helm chart for istio-csr
 | app.controller.leaderElectionNamespace | string | `"istio-system"` |  |
 | app.controller.rootCAConfigMapName | string | `"istio-ca-root-cert"` | Name of ConfigMap that should contain the root CA in all namespaces. |
 | app.logLevel | int | `1` | Verbosity of istio-csr logging. |
+| app.metrics.port | int | `9402` | Port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'. |
 | app.readinessProbe.path | string | `"/readyz"` | Path to expose istio-csr HTTP readiness probe on default network interface. |
 | app.readinessProbe.port | int | `6060` | Container port to expose istio-csr HTTP readiness probe on default network interface. |
 | app.server.clusterID | string | `"Kubernetes"` | The istio cluster ID to verify incoming CSRs. |

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.app.server.serving.port }}
+        - containerPort: {{ .Values.app.metrics.port }}
         readinessProbe:
           httpGet:
             port: {{ .Values.app.readinessProbe.port }}
@@ -30,6 +31,7 @@ spec:
         command: ["cert-manager-istio-csr"]
         args:
           - "--log-level={{.Values.app.logLevel}}"
+          - "--metrics-port={{.Values.app.metrics.port}}"
           - "--readiness-probe-port={{.Values.app.readinessProbe.port}}"
           - "--readiness-probe-path={{.Values.app.readinessProbe.path}}"
 

--- a/deploy/charts/istio-csr/templates/metrics-service.yaml
+++ b/deploy/charts/istio-csr/templates/metrics-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.app.metrics.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cert-manager-istio-csr.name" . }}-metrics
+  labels:
+    app: {{ include "cert-manager-istio-csr.name" . }}
+{{ include "cert-manager-istio-csr.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.app.metrics.service.type }}
+  ports:
+    - port: {{ .Values.app.metrics.port }}
+      targetPort: {{ .Values.app.metrics.port }}
+      protocol: TCP
+      name: metrics
+  selector:
+    app: {{ include "cert-manager-istio-csr.name" . }}
+{{- end }}

--- a/deploy/charts/istio-csr/templates/metrics-servicemonitor.yaml
+++ b/deploy/charts/istio-csr/templates/metrics-servicemonitor.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.app.metrics.service.enabled .Values.app.metrics.service.servicemonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "cert-manager-istio-csr.name" . }}
+  labels:
+    app: {{ include "cert-manager-istio-csr.name" . }}
+{{ include "cert-manager-istio-csr.labels" . | indent 4 }}
+    prometheus: {{ .Values.app.metrics.service.servicemonitor.prometheusInstance }}
+{{- if .Values.app.metrics.service.servicemonitor.labels }}
+{{ toYaml .Values.app.metrics.service.servicemonitor.labels | indent 4}}
+{{- end }}
+spec:
+  jobLabel: {{ include "cert-manager-istio-csr.name" . }}
+  selector:
+    matchLabels:
+      app: {{ include "cert-manager-istio-csr.name" . }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+  - targetPort: {{ .Values.app.metrics.port }}
+    path: "/metrics"
+    interval: {{ .Values.app.metrics.service.servicemonitor.interval }}
+    scrapeTimeout: {{ .Values.app.metrics.service.servicemonitor.scrapeTimeout }}
+{{- end }}

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -22,6 +22,19 @@ app:
   metrics:
     # -- Port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'.
     port: 9402
+    # -- Service to expose metrics endpoint.
+    service:
+      # -- Create a Service resource to expose metrics endpoint.
+      enabled: true
+      # -- Service type to expose metrics.
+      type: ClusterIP
+      # -- ServiceMonitor resource for this Service.
+      servicemonitor:
+        enabled: false
+        prometheusInstance: default
+        interval: 10s
+        scrapeTimeout: 5s
+        labels: {}
 
   readinessProbe:
     # -- Container port to expose istio-csr HTTP readiness probe on default network interface.

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -19,6 +19,10 @@ app:
   # -- Verbosity of istio-csr logging.
   logLevel: 1 # 1-5
 
+  metrics:
+    # -- Port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'.
+    port: 9402
+
   readinessProbe:
     # -- Container port to expose istio-csr HTTP readiness probe on default network interface.
     port: 6060

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,11 @@ go 1.15
 
 require (
 	github.com/go-logr/logr v0.4.0
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/jetstack/cert-manager v1.4.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
+	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	google.golang.org/grpc v1.38.0

--- a/go.sum
+++ b/go.sum
@@ -529,6 +529,7 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmg
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -105,7 +105,6 @@ func (s *Server) Start(ctx context.Context) error {
 	srvmetrics.EnableHandlingTimeHistogram(func(op *prom.HistogramOpts) { op.Namespace = "cert_manager_istio_csr" })
 	creds := credentials.NewTLS(s.tls.Config())
 	grpcServer := grpc.NewServer(
-		grpc.StreamInterceptor(srvmetrics.StreamServerInterceptor()),
 		grpc.UnaryInterceptor(srvmetrics.UnaryServerInterceptor()),
 		grpc.Creds(creds),
 	)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -26,7 +26,9 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	grpcprom "github.com/grpc-ecosystem/go-grpc-prometheus"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	prom "github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -38,13 +40,10 @@ import (
 	"istio.io/istio/security/pkg/server/ca/authenticate/kubeauth"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/cert-manager/istio-csr/pkg/certmanager"
 	"github.com/cert-manager/istio-csr/pkg/tls"
-)
-
-const (
-	IdentitiesAnnotationKey = "istio.cert-manager.io/identities"
 )
 
 type Options struct {
@@ -102,8 +101,20 @@ func New(log logr.Logger,
 // Start is a blocking func that will run the client facing certificate service
 func (s *Server) Start(ctx context.Context) error {
 	// Setup the grpc server using the passed TLS config
+	srvmetrics := grpcprom.NewServerMetrics(func(op *prom.CounterOpts) { op.Namespace = "cert_manager_istio_csr" })
+	srvmetrics.EnableHandlingTimeHistogram(func(op *prom.HistogramOpts) { op.Namespace = "cert_manager_istio_csr" })
 	creds := credentials.NewTLS(s.tls.Config())
-	grpcServer := grpc.NewServer(grpc.Creds(creds))
+	grpcServer := grpc.NewServer(
+		grpc.StreamInterceptor(srvmetrics.StreamServerInterceptor()),
+		grpc.UnaryInterceptor(srvmetrics.UnaryServerInterceptor()),
+		grpc.Creds(creds),
+	)
+
+	// Register gRPC Prometheus metrics
+	grpcprom.Register(grpcServer)
+	if err := metrics.Registry.Register(srvmetrics); err != nil {
+		return fmt.Errorf("failed to register gRPC Prometheus metrics: %w", err)
+	}
 
 	// listen on the configured address
 	listener, err := net.Listen("tcp", s.opts.ServingAddress)

--- a/test/e2e/suite/request/request.go
+++ b/test/e2e/suite/request/request.go
@@ -31,7 +31,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/cert-manager/istio-csr/pkg/server"
 	"github.com/cert-manager/istio-csr/test/e2e/framework"
 	cmclient "github.com/cert-manager/istio-csr/test/e2e/suite/internal/client"
 	"github.com/cert-manager/istio-csr/test/gen"
@@ -264,7 +263,7 @@ var _ = framework.CasesDescribe("Request Authentication", func() {
 
 		var createdCR *cmapi.CertificateRequest
 		for _, cr := range crs.Items {
-			if val, ok := cr.Annotations[server.IdentitiesAnnotationKey]; ok && val == id {
+			if val, ok := cr.Annotations["istio.cert-manager.io/identities"]; ok && val == id {
 				createdCR = &cr
 				break
 			}


### PR DESCRIPTION
This PR is branched from #71 which should be merged first.

This PR introduces exposed Prometheus metrics for:

- The tls provider:

The "success" label will be "1" after a successful request for the TLS serving certificate. It will be "0" otherwise.

```
# HELP cert_manager_istio_csr_tls_provider_certificate_requests Total number of certificate signing requests attempted for serving TLS. Success is 1 if there is no error, 0 otherwise.
# TYPE cert_manager_istio_csr_tls_provider_certificate_requests counter
cert_manager_istio_csr_tls_provider_certificate_requests{success="0"} 2
cert_manager_istio_csr_tls_provider_certificate_requests{success="1"} 11
```

-  grpc service:

This includes the request duration and the status code of `CreateCertificate`.

```
# HELP cert_manager_istio_csr_grpc_server_handled_total Total number of RPCs completed on the server, regardless of success or failure.
# TYPE cert_manager_istio_csr_grpc_server_handled_total counter
cert_manager_istio_csr_grpc_server_handled_total{grpc_code="OK",grpc_method="CreateCertificate",grpc_service="istio.v1.auth.IstioCertificateService",grpc_type="unary"} 1
cert_manager_istio_csr_grpc_server_handled_total{grpc_code="Unauthenticated",grpc_method="CreateCertificate",grpc_service="istio.v1.auth.IstioCertificateService",grpc_type="unary"} 3
# HELP cert_manager_istio_csr_grpc_server_handling_seconds Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.
# TYPE cert_manager_istio_csr_grpc_server_handling_seconds histogram
cert_manager_istio_csr_grpc_server_handling_seconds_bucket{grpc_method="CreateCertificate",grpc_service="istio.v1.auth.IstioCertificateService",grpc_type="unary",le="0.005"} 3
cert_manager_istio_csr_grpc_server_handling_seconds_bucket{grpc_method="CreateCertificate",grpc_service="istio.v1.auth.IstioCertificateService",grpc_type="unary",le="0.01"} 3
cert_manager_istio_csr_grpc_server_handling_seconds_bucket{grpc_method="CreateCertificate",grpc_service="istio.v1.auth.IstioCertificateService",grpc_type="unary",le="0.025"} 4
cert_manager_istio_csr_grpc_server_handling_seconds_bucket{grpc_method="CreateCertificate",grpc_service="istio.v1.auth.IstioCertificateService",grpc_type="unary",le="0.05"} 4
cert_manager_istio_csr_grpc_server_handling_seconds_bucket{grpc_method="CreateCertificate",grpc_service="istio.v1.auth.IstioCertificateService",grpc_type="unary",le="0.1"} 4
cert_manager_istio_csr_grpc_server_handling_seconds_bucket{grpc_method="CreateCertificate",grpc_service="istio.v1.auth.IstioCertificateService",grpc_type="unary",le="0.25"} 4
cert_manager_istio_csr_grpc_server_handling_seconds_bucket{grpc_method="CreateCertificate",grpc_service="istio.v1.auth.IstioCertificateService",grpc_type="unary",le="0.5"} 4
cert_manager_istio_csr_grpc_server_handling_seconds_bucket{grpc_method="CreateCertificate",grpc_service="istio.v1.auth.IstioCertificateService",grpc_type="unary",le="1"} 4
cert_manager_istio_csr_grpc_server_handling_seconds_bucket{grpc_method="CreateCertificate",grpc_service="istio.v1.auth.IstioCertificateService",grpc_type="unary",le="2.5"} 4
cert_manager_istio_csr_grpc_server_handling_seconds_bucket{grpc_method="CreateCertificate",grpc_service="istio.v1.auth.IstioCertificateService",grpc_type="unary",le="5"} 4
cert_manager_istio_csr_grpc_server_handling_seconds_bucket{grpc_method="CreateCertificate",grpc_service="istio.v1.auth.IstioCertificateService",grpc_type="unary",le="10"} 4
cert_manager_istio_csr_grpc_server_handling_seconds_bucket{grpc_method="CreateCertificate",grpc_service="istio.v1.auth.IstioCertificateService",grpc_type="unary",le="+Inf"} 4
cert_manager_istio_csr_grpc_server_handling_seconds_sum{grpc_method="CreateCertificate",grpc_service="istio.v1.auth.IstioCertificateService",grpc_type="unary"} 0.030193990000000004
cert_manager_istio_csr_grpc_server_handling_seconds_count{grpc_method="CreateCertificate",grpc_service="istio.v1.auth.IstioCertificateService",grpc_type="unary"} 4
# HELP cert_manager_istio_csr_grpc_server_msg_received_total Total number of RPC stream messages received on the server.
# TYPE cert_manager_istio_csr_grpc_server_msg_received_total counter
cert_manager_istio_csr_grpc_server_msg_received_total{grpc_method="CreateCertificate",grpc_service="istio.v1.auth.IstioCertificateService",grpc_type="unary"} 5
# HELP cert_manager_istio_csr_grpc_server_msg_sent_total Total number of gRPC stream messages sent by the server.
# TYPE cert_manager_istio_csr_grpc_server_msg_sent_total counter
cert_manager_istio_csr_grpc_server_msg_sent_total{grpc_method="CreateCertificate",grpc_service="istio.v1.auth.IstioCertificateService",grpc_type="unary"} 1
# HELP cert_manager_istio_csr_grpc_server_started_total Total number of RPCs started on the server.
# TYPE cert_manager_istio_csr_grpc_server_started_total counter
cert_manager_istio_csr_grpc_server_started_total{grpc_method="CreateCertificate",grpc_service="istio.v1.auth.IstioCertificateService",grpc_type="unary"} 5
```

- Generate go process stats:
```
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 2.1434e-05
go_gc_duration_seconds{quantile="0.25"} 3.8796e-05
go_gc_duration_seconds{quantile="0.5"} 5.52e-05
go_gc_duration_seconds{quantile="0.75"} 8.6315e-05
go_gc_duration_seconds{quantile="1"} 0.00127619
go_gc_duration_seconds_sum 0.002427678
go_gc_duration_seconds_count 17
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 63
....
```

- Generate controller-runtime stats:

```
# HELP controller_runtime_active_workers Number of currently used workers per controller
# TYPE controller_runtime_active_workers gauge
controller_runtime_active_workers{controller="configmap"} 0
controller_runtime_active_workers{controller="namespace"} 0
# HELP controller_runtime_max_concurrent_reconciles Maximum number of concurrent reconciles per controller
# TYPE controller_runtime_max_concurrent_reconciles gauge
controller_runtime_max_concurrent_reconciles{controller="configmap"} 1
controller_runtime_max_concurrent_reconciles{controller="namespace"} 1
# HELP controller_runtime_reconcile_errors_total Total number of reconciliation errors per controller
# TYPE controller_runtime_reconcile_errors_total counter
controller_runtime_reconcile_errors_total{controller="configmap"} 221
controller_runtime_reconcile_errors_total{controller="namespace"} 0
# HELP controller_runtime_reconcile_time_seconds Length of time per reconciliation per controller
# TYPE controller_runtime_reconcile_time_seconds histogram
controller_runtime_reconcile_time_seconds_bucket{controller="configmap",le="0.005"} 43
controller_runtime_reconcile_time_seconds_bucket{controller="configmap",le="0.01"} 43
controller_runtime_reconcile_time_seconds_bucket{controller="configmap",le="0.025"} 43
controller_runtime_reconcile_time_seconds_bucket{controller="configmap",le="0.05"} 43
controller_runtime_reconcile_time_seconds_bucket{controller="configmap",le="0.1"} 133
```

- Kubernetes client stats:

```
# HELP rest_client_request_latency_seconds Request latency in seconds. Broken down by verb and URL.
# TYPE rest_client_request_latency_seconds histogram
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/configmaps?limit=%7Bvalue%7D&resourceVersion=%7Bvalue%7D",verb="GET",le="0.001"} 0
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/configmaps?limit=%7Bvalue%7D&resourceVersion=%7Bvalue%7D",verb="GET",le="0.002"} 0
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/configmaps?limit=%7Bvalue%7D&resourceVersion=%7Bvalue%7D",verb="GET",le="0.004"} 0
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/configmaps?limit=%7Bvalue%7D&resourceVersion=%7Bvalue%7D",verb="GET",le="0.008"} 0
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/configmaps?limit=%7Bvalue%7D&resourceVersion=%7Bvalue%7D",verb="GET",le="0.016"} 1
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/configmaps?limit=%7Bvalue%7D&resourceVersion=%7Bvalue%7D",verb="GET",le="0.032"} 1
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/configmaps?limit=%7Bvalue%7D&resourceVersion=%7Bvalue%7D",verb="GET",le="0.064"} 1
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/configmaps?limit=%7Bvalue%7D&resourceVersion=%7Bvalue%7D",verb="GET",le="0.128"} 1
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/configmaps?limit=%7Bvalue%7D&resourceVersion=%7Bvalue%7D",verb="GET",le="0.256"} 1
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/configmaps?limit=%7Bvalue%7D&resourceVersion=%7Bvalue%7D",verb="GET",le="0.512"} 1
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/configmaps?limit=%7Bvalue%7D&resourceVersion=%7Bvalue%7D",verb="GET",le="+Inf"} 1
rest_client_request_latency_seconds_sum{url="https://10.96.0.1:443/api/v1/configmaps?limit=%7Bvalue%7D&resourceVersion=%7Bvalue%7D",verb="GET"} 0.010268499
rest_client_request_latency_seconds_count{url="https://10.96.0.1:443/api/v1/configmaps?limit=%7Bvalue%7D&resourceVersion=%7Bvalue%7D",verb="GET"} 1
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps",verb="POST",le="0.001"} 15
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps",verb="POST",le="0.002"} 22
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps",verb="POST",le="0.004"} 36
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps",verb="POST",le="0.008"} 40
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps",verb="POST",le="0.016"} 41
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps",verb="POST",le="0.032"} 42
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps",verb="POST",le="0.064"} 129
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps",verb="POST",le="0.128"} 133
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps",verb="POST",le="0.256"} 242
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps",verb="POST",le="0.512"} 242
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps",verb="POST",le="+Inf"} 242
rest_client_request_latency_seconds_sum{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps",verb="POST"} 26.81313412100001
rest_client_request_latency_seconds_count{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps",verb="POST"} 242
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="GET",le="0.001"} 2
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="GET",le="0.002"} 188
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="GET",le="0.004"} 289
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="GET",le="0.008"} 292
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="GET",le="0.016"} 293
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="GET",le="0.032"} 296
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="GET",le="0.064"} 296
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="GET",le="0.128"} 296
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="GET",le="0.256"} 296
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="GET",le="0.512"} 296
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="GET",le="+Inf"} 296
rest_client_request_latency_seconds_sum{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="GET"} 0.6367641060000006
rest_client_request_latency_seconds_count{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="GET"} 296
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="PUT",le="0.001"} 0
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="PUT",le="0.002"} 258
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="PUT",le="0.004"} 289
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="PUT",le="0.008"} 295
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="PUT",le="0.016"} 295
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="PUT",le="0.032"} 295
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="PUT",le="0.064"} 295
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="PUT",le="0.128"} 295
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="PUT",le="0.256"} 295
rest_client_request_latency_seconds_bucket{url="https://10.96.0.1:443/api/v1/namespaces/%7Bnamespace%7D/configmaps/%7Bname%7D",verb="PUT",le="0.512"} 295
....
````


/assign @jakexks 
/cc @SpectralHiss
fixes #65 
