### PR TITLE
Change delete CertificateRequest to defer so it is always done

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	google.golang.org/grpc v1.38.0
+	google.golang.org/protobuf v1.26.0
 	istio.io/api v0.0.0-20210617183632-a1ac914aead5
 	istio.io/istio v0.0.0-20210621105413-9868a6392ce3
 	istio.io/pkg v0.0.0-20210618150320-2df9dbfcd1b1

--- a/pkg/certmanager/certmanager_test.go
+++ b/pkg/certmanager/certmanager_test.go
@@ -19,6 +19,7 @@ package certmanager
 import (
 	"context"
 	"testing"
+	"time"
 
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
@@ -223,6 +224,9 @@ func Test_Sign(t *testing.T) {
 			if (err != nil) != test.expErr {
 				t.Errorf("unexpected error, exp=%t got=%v", test.expErr, err)
 			}
+
+			// Wait for delete go routine to finish
+			time.Sleep(time.Millisecond * 50)
 
 			if !apiequality.Semantic.DeepEqual(bundle, test.expBundle) {
 				t.Errorf("unexpected returned bundle, exp=%v got=%v", test.expBundle, bundle)

--- a/pkg/certmanager/certmanager_test.go
+++ b/pkg/certmanager/certmanager_test.go
@@ -1,0 +1,450 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certmanager
+
+import (
+	"context"
+	"testing"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	"github.com/jetstack/cert-manager/pkg/client/clientset/versioned/fake"
+	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/watch"
+	coretesting "k8s.io/client-go/testing"
+	"k8s.io/klog/v2/klogr"
+
+	"github.com/cert-manager/istio-csr/test/gen"
+)
+
+func Test_Sign(t *testing.T) {
+	tests := map[string]struct {
+		client      func() *fake.Clientset
+		preserveCRs bool
+
+		expBundle Bundle
+		expObject bool
+		expErr    bool
+	}{
+		"preserveCRs=true if request is denied, return error": {
+			client: func() *fake.Clientset {
+				client := fake.NewSimpleClientset(
+					gen.CertificateRequest("test-cr"),
+				)
+				client.PrependWatchReactor("*", func(coretesting.Action) (bool, watch.Interface, error) {
+					watcher := watch.NewFake()
+					go func() {
+						watcher.Modify(gen.CertificateRequest("test-cr"))
+						watcher.Modify(gen.CertificateRequest("test-cr",
+							gen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+								Type:   cmapi.CertificateRequestConditionDenied,
+								Status: cmmeta.ConditionTrue,
+							}),
+						))
+					}()
+					return true, watcher, nil
+				})
+				return client
+			},
+			preserveCRs: true,
+
+			expObject: true,
+			expBundle: Bundle{},
+			expErr:    true,
+		},
+
+		"preserveCRs=false if request is denied, return error and delete object": {
+			client: func() *fake.Clientset {
+				client := fake.NewSimpleClientset(
+					gen.CertificateRequest("test-cr"),
+				)
+				client.PrependWatchReactor("*", func(coretesting.Action) (bool, watch.Interface, error) {
+					watcher := watch.NewFake()
+					go func() {
+						watcher.Modify(gen.CertificateRequest("test-cr"))
+						watcher.Modify(gen.CertificateRequest("test-cr",
+							gen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+								Type:   cmapi.CertificateRequestConditionDenied,
+								Status: cmmeta.ConditionTrue,
+							}),
+						))
+					}()
+					return true, watcher, nil
+				})
+				return client
+			},
+			preserveCRs: false,
+
+			expObject: false,
+			expBundle: Bundle{},
+			expErr:    true,
+		},
+
+		"preserveCRs=true if request is failed, return error": {
+			client: func() *fake.Clientset {
+				client := fake.NewSimpleClientset(
+					gen.CertificateRequest("test-cr"),
+				)
+				client.PrependWatchReactor("*", func(coretesting.Action) (bool, watch.Interface, error) {
+					watcher := watch.NewFake()
+					go func() {
+						watcher.Modify(gen.CertificateRequest("test-cr"))
+						watcher.Modify(gen.CertificateRequest("test-cr",
+							gen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+								Type:   cmapi.CertificateRequestConditionReady,
+								Status: cmmeta.ConditionFalse,
+								Reason: cmapi.CertificateRequestReasonFailed,
+							}),
+						))
+					}()
+					return true, watcher, nil
+				})
+				return client
+			},
+			preserveCRs: true,
+
+			expObject: true,
+			expBundle: Bundle{},
+			expErr:    true,
+		},
+
+		"preserveCRs=false if request is failed, return error and delete object": {
+			client: func() *fake.Clientset {
+				client := fake.NewSimpleClientset(
+					gen.CertificateRequest("test-cr"),
+				)
+				client.PrependWatchReactor("*", func(coretesting.Action) (bool, watch.Interface, error) {
+					watcher := watch.NewFake()
+					go func() {
+						watcher.Modify(gen.CertificateRequest("test-cr"))
+						watcher.Modify(gen.CertificateRequest("test-cr",
+							gen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+								Type:   cmapi.CertificateRequestConditionReady,
+								Status: cmmeta.ConditionFalse,
+								Reason: cmapi.CertificateRequestReasonFailed,
+							}),
+						))
+					}()
+					return true, watcher, nil
+				})
+				return client
+			},
+			preserveCRs: false,
+
+			expObject: false,
+			expBundle: Bundle{},
+			expErr:    true,
+		},
+
+		"preserveCRs=true if request is signed, return bundle": {
+			client: func() *fake.Clientset {
+				client := fake.NewSimpleClientset(
+					gen.CertificateRequest("test-cr"),
+				)
+				client.PrependWatchReactor("*", func(coretesting.Action) (bool, watch.Interface, error) {
+					watcher := watch.NewFake()
+					go func() {
+						watcher.Modify(gen.CertificateRequest("test-cr"))
+						watcher.Modify(gen.CertificateRequest("test-cr",
+							gen.SetCertificateRequestCertificate([]byte("signed-cert")),
+							gen.SetCertificateRequestCA([]byte("ca")),
+						))
+					}()
+					return true, watcher, nil
+				})
+				return client
+			},
+			preserveCRs: true,
+
+			expObject: true,
+			expBundle: Bundle{
+				Certificate: []byte("signed-cert"),
+				CA:          []byte("ca"),
+			},
+			expErr: false,
+		},
+
+		"preserveCRs=false if request is signed, return bundle and delete object": {
+			client: func() *fake.Clientset {
+				client := fake.NewSimpleClientset(
+					gen.CertificateRequest("test-cr"),
+				)
+				client.PrependWatchReactor("*", func(coretesting.Action) (bool, watch.Interface, error) {
+					watcher := watch.NewFake()
+					go func() {
+						watcher.Modify(gen.CertificateRequest("test-cr"))
+						watcher.Modify(gen.CertificateRequest("test-cr",
+							gen.SetCertificateRequestCertificate([]byte("signed-cert")),
+							gen.SetCertificateRequestCA([]byte("ca")),
+						))
+					}()
+					return true, watcher, nil
+				})
+				return client
+			},
+			preserveCRs: false,
+
+			expObject: false,
+			expBundle: Bundle{
+				Certificate: []byte("signed-cert"),
+				CA:          []byte("ca"),
+			},
+			expErr: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := test.client()
+			m := &Manager{
+				client: client.CertmanagerV1().CertificateRequests(gen.DefaultTestNamespace),
+				log:    klogr.New(),
+				opts: Options{
+					PreserveCertificateRequests: test.preserveCRs,
+				},
+			}
+
+			bundle, err := m.Sign(context.TODO(), "", nil, 0, nil)
+			if (err != nil) != test.expErr {
+				t.Errorf("unexpected error, exp=%t got=%v", test.expErr, err)
+			}
+
+			if !apiequality.Semantic.DeepEqual(bundle, test.expBundle) {
+				t.Errorf("unexpected returned bundle, exp=%v got=%v", test.expBundle, bundle)
+			}
+
+			var deleted bool
+			for _, a := range client.Fake.Actions() {
+				if a.GetVerb() == "delete" {
+					deleted = true
+					break
+				}
+			}
+
+			if test.expObject == deleted {
+				t.Errorf("unexpected returned CertificateRequest remaining, exp=%t got=%t", test.expObject, !deleted)
+			}
+		})
+	}
+}
+
+func Test_waitForCertificateRequest(t *testing.T) {
+	tests := map[string]struct {
+		client func() cmclient.CertificateRequestInterface
+
+		expResult *cmapi.CertificateRequest
+		expErr    bool
+	}{
+		"if the request does not exist, should return with error": {
+			client: func() cmclient.CertificateRequestInterface {
+				return fake.NewSimpleClientset().CertmanagerV1().CertificateRequests(gen.DefaultTestNamespace)
+			},
+
+			expResult: nil,
+			expErr:    true,
+		},
+		"if the request is denied, should return with error": {
+			client: func() cmclient.CertificateRequestInterface {
+				return fake.NewSimpleClientset(
+					gen.CertificateRequest("test-cr",
+						gen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+							Type:   cmapi.CertificateRequestConditionDenied,
+							Status: cmmeta.ConditionTrue,
+						}),
+					)).CertmanagerV1().CertificateRequests(gen.DefaultTestNamespace)
+			},
+
+			expResult: gen.CertificateRequest("test-cr",
+				gen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+					Type:   cmapi.CertificateRequestConditionDenied,
+					Status: cmmeta.ConditionTrue,
+				})),
+			expErr: true,
+		},
+
+		"if the request has failed, should return with error": {
+			client: func() cmclient.CertificateRequestInterface {
+				return fake.NewSimpleClientset(
+					gen.CertificateRequest("test-cr",
+						gen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+							Type:   cmapi.CertificateRequestConditionReady,
+							Status: cmmeta.ConditionFalse,
+							Reason: cmapi.CertificateRequestReasonFailed,
+						}),
+					)).CertmanagerV1().CertificateRequests(gen.DefaultTestNamespace)
+			},
+
+			expResult: gen.CertificateRequest("test-cr",
+				gen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+					Type:   cmapi.CertificateRequestConditionReady,
+					Status: cmmeta.ConditionFalse,
+					Reason: cmapi.CertificateRequestReasonFailed,
+				})),
+			expErr: true,
+		},
+
+		"if the request has been signed, should return with no error": {
+			client: func() cmclient.CertificateRequestInterface {
+				return fake.NewSimpleClientset(
+					gen.CertificateRequest("test-cr",
+						gen.SetCertificateRequestCertificate([]byte("signed-cert")),
+					),
+				).CertmanagerV1().CertificateRequests(gen.DefaultTestNamespace)
+			},
+
+			expResult: gen.CertificateRequest("test-cr",
+				gen.SetCertificateRequestCertificate([]byte("signed-cert")),
+			),
+			expErr: false,
+		},
+
+		"if the request is not signed then receives denied update, should return with error": {
+			client: func() cmclient.CertificateRequestInterface {
+				client := fake.NewSimpleClientset(
+					gen.CertificateRequest("test-cr"),
+				)
+				client.PrependWatchReactor("*", func(coretesting.Action) (bool, watch.Interface, error) {
+					watcher := watch.NewFake()
+					go func() {
+						watcher.Modify(gen.CertificateRequest("test-cr"))
+						watcher.Modify(gen.CertificateRequest("test-cr",
+							gen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+								Type:   cmapi.CertificateRequestConditionDenied,
+								Status: cmmeta.ConditionTrue,
+							}),
+						))
+					}()
+					return true, watcher, nil
+				})
+				return client.CertmanagerV1().CertificateRequests(gen.DefaultTestNamespace)
+			},
+
+			expResult: gen.CertificateRequest("test-cr",
+				gen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+					Type:   cmapi.CertificateRequestConditionDenied,
+					Status: cmmeta.ConditionTrue,
+				}),
+			),
+			expErr: true,
+		},
+		"if the request is not signed then receives failed update, should return with error": {
+			client: func() cmclient.CertificateRequestInterface {
+				client := fake.NewSimpleClientset(
+					gen.CertificateRequest("test-cr"),
+				)
+				client.PrependWatchReactor("*", func(coretesting.Action) (bool, watch.Interface, error) {
+					watcher := watch.NewFake()
+					go func() {
+						watcher.Modify(gen.CertificateRequest("test-cr"))
+						watcher.Modify(gen.CertificateRequest("test-cr",
+							gen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+								Type:   cmapi.CertificateRequestConditionReady,
+								Status: cmmeta.ConditionFalse,
+								Reason: cmapi.CertificateRequestReasonFailed,
+							}),
+						))
+					}()
+					return true, watcher, nil
+				})
+				return client.CertmanagerV1().CertificateRequests(gen.DefaultTestNamespace)
+			},
+
+			expResult: gen.CertificateRequest("test-cr",
+				gen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+					Type:   cmapi.CertificateRequestConditionReady,
+					Status: cmmeta.ConditionFalse,
+					Reason: cmapi.CertificateRequestReasonFailed,
+				}),
+			),
+			expErr: true,
+		},
+		"if the request is not signed then receives signed update, should return with no error": {
+			client: func() cmclient.CertificateRequestInterface {
+				client := fake.NewSimpleClientset(
+					gen.CertificateRequest("test-cr"),
+				)
+				client.PrependWatchReactor("*", func(coretesting.Action) (bool, watch.Interface, error) {
+					watcher := watch.NewFake()
+					go func() {
+						watcher.Modify(gen.CertificateRequest("test-cr"))
+						watcher.Modify(gen.CertificateRequest("test-cr",
+							gen.SetCertificateRequestCertificate([]byte("signed-cert")),
+						))
+					}()
+					return true, watcher, nil
+				})
+				return client.CertmanagerV1().CertificateRequests(gen.DefaultTestNamespace)
+			},
+
+			expResult: gen.CertificateRequest("test-cr",
+				gen.SetCertificateRequestCertificate([]byte("signed-cert")),
+			),
+			expErr: false,
+		},
+		"if the request is not signed then gets deleted, should return with error": {
+			client: func() cmclient.CertificateRequestInterface {
+				client := fake.NewSimpleClientset(
+					gen.CertificateRequest("test-cr"),
+				)
+				client.PrependWatchReactor("*", func(coretesting.Action) (bool, watch.Interface, error) {
+					watcher := watch.NewFake()
+					go func() {
+						watcher.Modify(gen.CertificateRequest("test-cr"))
+						watcher.Delete(gen.CertificateRequest("test-cr",
+							gen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+								Type:   cmapi.CertificateRequestConditionReady,
+								Status: cmmeta.ConditionFalse,
+								Reason: "random condition",
+							}),
+						))
+					}()
+					return true, watcher, nil
+				})
+				return client.CertmanagerV1().CertificateRequests(gen.DefaultTestNamespace)
+			},
+
+			expResult: gen.CertificateRequest("test-cr",
+				gen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+					Type:   cmapi.CertificateRequestConditionReady,
+					Status: cmmeta.ConditionFalse,
+					Reason: "random condition",
+				}),
+			),
+
+			expErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			m := &Manager{
+				client: test.client(),
+			}
+
+			log := klogr.New()
+			cr, err := m.waitForCertificateRequest(context.TODO(), log, gen.CertificateRequest("test-cr"))
+			if (err != nil) != test.expErr {
+				t.Errorf("unexpected error, exp=%t got=%v", test.expErr, err)
+			}
+
+			if !apiequality.Semantic.DeepEqual(cr, test.expResult) {
+				t.Errorf("unexpected returned CertificateRequest, exp=%#+v got=%#+v", test.expResult, cr)
+			}
+		})
+	}
+}

--- a/pkg/certmanager/certmanager_test.go
+++ b/pkg/certmanager/certmanager_test.go
@@ -211,7 +211,7 @@ func Test_Sign(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			client := test.client()
-			m := &Manager{
+			m := &manager{
 				client: client.CertmanagerV1().CertificateRequests(gen.DefaultTestNamespace),
 				log:    klogr.New(),
 				opts: Options{
@@ -432,7 +432,7 @@ func Test_waitForCertificateRequest(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			m := &Manager{
+			m := &manager{
 				client: test.client(),
 			}
 

--- a/pkg/certmanager/fake/fake.go
+++ b/pkg/certmanager/fake/fake.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+	"time"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+
+	"github.com/cert-manager/istio-csr/pkg/certmanager"
+)
+
+type signFn func(context.Context, string, []byte, time.Duration, []cmapi.KeyUsage) (certmanager.Bundle, error)
+
+type Fake struct {
+	sign signFn
+}
+
+func New() *Fake {
+	return &Fake{
+		sign: func(context.Context, string, []byte, time.Duration, []cmapi.KeyUsage) (certmanager.Bundle, error) {
+			return certmanager.Bundle{}, nil
+		},
+	}
+}
+
+func (f *Fake) WithSign(fn signFn) *Fake {
+	f.sign = fn
+	return f
+}
+
+func (f *Fake) Sign(ctx context.Context, identities string, csrPEM []byte, duration time.Duration, usages []cmapi.KeyUsage) (certmanager.Bundle, error) {
+	return f.sign(ctx, identities, csrPEM, duration, usages)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -66,7 +66,7 @@ type Server struct {
 
 	auther security.Authenticator
 
-	cm  *certmanager.Manager
+	cm  certmanager.Interface
 	tls *tls.Provider
 
 	ready bool
@@ -75,7 +75,7 @@ type Server struct {
 
 func New(log logr.Logger,
 	restConfig *rest.Config,
-	cm *certmanager.Manager,
+	cm certmanager.Interface,
 	tls *tls.Provider,
 	opts Options,
 ) (*Server, error) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	securityapi "istio.io/api/security/v1alpha1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/klog/v2/klogr"
+
+	"github.com/cert-manager/istio-csr/pkg/certmanager"
+	cmfake "github.com/cert-manager/istio-csr/pkg/certmanager/fake"
+	"github.com/cert-manager/istio-csr/test/gen"
+)
+
+func Test_CreateCertificate(t *testing.T) {
+	spiffeDomain := "spiffe://foo"
+
+	tests := map[string]struct {
+		icr func(t *testing.T) *securityapi.IstioCertificateRequest
+
+		cm          func(t *testing.T) certmanager.Interface
+		maxDuration time.Duration
+
+		expResponse *securityapi.IstioCertificateResponse
+		expErr      error
+	}{
+		"if authn fails, should return Unauthenticated error code": {
+			icr: func(t *testing.T) *securityapi.IstioCertificateRequest {
+				return &securityapi.IstioCertificateRequest{
+					Csr: string(gen.MustCSR(t,
+						gen.SetCSRIdentities([]string{"spiffe://bar"}),
+					)),
+				}
+			},
+			cm:          func(t *testing.T) certmanager.Interface { return cmfake.New() },
+			expResponse: nil,
+			expErr:      status.Error(codes.Unauthenticated, "request authenticate failure"),
+		},
+		"if authn succeeds but sign fails, should return Internal error code": {
+			icr: func(t *testing.T) *securityapi.IstioCertificateRequest {
+				return &securityapi.IstioCertificateRequest{
+					Csr: string(gen.MustCSR(t,
+						gen.SetCSRIdentities([]string{spiffeDomain}),
+					)),
+				}
+			},
+			cm: func(t *testing.T) certmanager.Interface {
+				return cmfake.New().WithSign(func(_ context.Context, identity string, _ []byte, _ time.Duration, _ []cmapi.KeyUsage) (certmanager.Bundle, error) {
+					if identity != spiffeDomain {
+						t.Errorf("unexpected identity, exp=%s got=%s", spiffeDomain, identity)
+					}
+					return certmanager.Bundle{}, errors.New("generic error")
+				})
+			},
+			maxDuration: time.Hour,
+			expResponse: nil,
+			expErr:      status.Error(codes.Internal, "failed to sign certificate request"),
+		},
+		"if authn and sign succeeds, should sign certificate with given duration and respond": {
+			icr: func(t *testing.T) *securityapi.IstioCertificateRequest {
+				return &securityapi.IstioCertificateRequest{
+					Csr: string(gen.MustCSR(t,
+						gen.SetCSRIdentities([]string{spiffeDomain}),
+					)),
+					ValidityDuration: 60 * 30,
+				}
+			},
+			cm: func(t *testing.T) certmanager.Interface {
+				return cmfake.New().WithSign(func(_ context.Context, identity string, _ []byte, dur time.Duration, _ []cmapi.KeyUsage) (certmanager.Bundle, error) {
+					if identity != spiffeDomain {
+						t.Errorf("unexpected identity, exp=%s got=%s", spiffeDomain, identity)
+					}
+
+					if dur != time.Minute*30 {
+						t.Errorf("unexpected requested duration, exp=%s got=%s", time.Minute*30, dur)
+					}
+
+					return certmanager.Bundle{Certificate: []byte("signed-cert"), CA: []byte("ca")}, nil
+				})
+			},
+			maxDuration: time.Hour * 2,
+			expResponse: &securityapi.IstioCertificateResponse{
+				CertChain: []string{
+					"signed-cert",
+					"ca",
+				},
+			},
+			expErr: nil,
+		},
+		"if authn and sign succeeds, should sign certificate with maximum duration and respond": {
+			icr: func(t *testing.T) *securityapi.IstioCertificateRequest {
+				return &securityapi.IstioCertificateRequest{
+					Csr: string(gen.MustCSR(t,
+						gen.SetCSRIdentities([]string{spiffeDomain}),
+					)),
+					ValidityDuration: 60 * 60,
+				}
+			},
+			cm: func(t *testing.T) certmanager.Interface {
+				return cmfake.New().WithSign(func(_ context.Context, identity string, _ []byte, dur time.Duration, _ []cmapi.KeyUsage) (certmanager.Bundle, error) {
+					if identity != spiffeDomain {
+						t.Errorf("unexpected identity, exp=%s got=%s", spiffeDomain, identity)
+					}
+
+					if dur != time.Hour/2 {
+						t.Errorf("unexpected requested duration, exp=%s got=%s", time.Hour/2, dur)
+					}
+
+					return certmanager.Bundle{Certificate: []byte("signed-cert"), CA: []byte("ca")}, nil
+				})
+			},
+			maxDuration: time.Hour / 2,
+			expResponse: &securityapi.IstioCertificateResponse{
+				CertChain: []string{
+					"signed-cert",
+					"ca",
+				},
+			},
+			expErr: nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			s := &Server{
+				opts: Options{
+					MaximumClientCertificateDuration: test.maxDuration,
+				},
+				auther: newMockAuthn([]string{spiffeDomain}, ""),
+				log:    klogr.New(),
+				cm:     test.cm(t),
+			}
+
+			resp, err := s.CreateCertificate(context.TODO(), test.icr(t))
+			errS, _ := status.FromError(err)
+			expErrS, _ := status.FromError(test.expErr)
+
+			if !proto.Equal(errS.Proto(), expErrS.Proto()) {
+				t.Errorf("unexpected error, exp=%v got=%v", test.expErr, err)
+			}
+
+			if !apiequality.Semantic.DeepEqual(resp, test.expResponse) {
+				t.Errorf("unexpected response, exp=%v got=%v", test.expResponse, resp)
+			}
+		})
+	}
+}

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -83,14 +83,14 @@ type Provider struct {
 
 	rootCA []byte
 
-	cm *certmanager.Manager
+	cm certmanager.Interface
 
 	lock      sync.RWMutex
 	tlsConfig *tls.Config
 }
 
 // NewProvider will return a new provider where a TLS config is ready to be fetched.
-func NewProvider(log logr.Logger, cm *certmanager.Manager, opts Options) (*Provider, error) {
+func NewProvider(log logr.Logger, cm certmanager.Interface, opts Options) (*Provider, error) {
 	var (
 		rootCA []byte
 		err    error
@@ -116,8 +116,6 @@ func NewProvider(log logr.Logger, cm *certmanager.Manager, opts Options) (*Provi
 // provide a TLS config based on it. Keep this certificate renewed. Blocking
 // function.
 func (p *Provider) Start(ctx context.Context) error {
-	// Before returning with the provider, we set a valid, up-to-date TLS
-	// config is ready for serving.
 	notAfter, err := p.fetchCertificate(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to fetch initial serving certificate: %w", err)

--- a/test/gen/certificaterequest.go
+++ b/test/gen/certificaterequest.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gen
+
+import (
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+)
+
+type CertificateRequestModifier func(*cmapi.CertificateRequest)
+
+func CertificateRequest(name string, mods ...CertificateRequestModifier) *cmapi.CertificateRequest {
+	c := &cmapi.CertificateRequest{
+		ObjectMeta: ObjectMeta(name),
+	}
+	for _, mod := range mods {
+		mod(c)
+	}
+	return c
+}
+
+func CertificateRequestFrom(cr *cmapi.CertificateRequest, mods ...CertificateRequestModifier) *cmapi.CertificateRequest {
+	cr = cr.DeepCopy()
+	for _, mod := range mods {
+		mod(cr)
+	}
+	return cr
+}
+
+func AddCertificateRequestStatusCondition(c cmapi.CertificateRequestCondition) CertificateRequestModifier {
+	return func(cr *cmapi.CertificateRequest) {
+		cr.Status.Conditions = append(cr.Status.Conditions, c)
+	}
+}
+
+func SetCertificateRequestCertificate(certPEM []byte) CertificateRequestModifier {
+	return func(cr *cmapi.CertificateRequest) {
+		cr.Status.Certificate = certPEM
+	}
+}
+
+func SetCertificateRequestCA(caPEM []byte) CertificateRequestModifier {
+	return func(cr *cmapi.CertificateRequest) {
+		cr.Status.CA = caPEM
+	}
+}


### PR DESCRIPTION
fixes #73 

This PR moves the deletion of CertificateRequests to a defer, which means they are _always_ deleted when not preserving, even if the request failed.

We also catch cases in the watcher where the request may have been deleted out of band.

Adds unit tests for the cert-manager package.

/assign @irbekrm  