### PR TITLE
Pass context to tls.GetConfig so it returns when context is canceled

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -100,10 +100,15 @@ func New(log logr.Logger,
 
 // Start is a blocking func that will run the client facing certificate service
 func (s *Server) Start(ctx context.Context) error {
-	// Setup the grpc server using the passed TLS config
+	tlsConfig, err := s.tls.Config(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Setup the grpc server using the provided TLS config
 	srvmetrics := grpcprom.NewServerMetrics(func(op *prom.CounterOpts) { op.Namespace = "cert_manager_istio_csr" })
 	srvmetrics.EnableHandlingTimeHistogram(func(op *prom.HistogramOpts) { op.Namespace = "cert_manager_istio_csr" })
-	creds := credentials.NewTLS(s.tls.Config())
+	creds := credentials.NewTLS(tlsConfig)
 	grpcServer := grpc.NewServer(
 		grpc.UnaryInterceptor(srvmetrics.UnaryServerInterceptor()),
 		grpc.Creds(creds),


### PR DESCRIPTION
Signed-off-by: joshvanl <vleeuwenjoshua@gmail.com>

Small cleanup PR to pass in context to the `tls.Config` function. This allows the function to return when the context has been cancelled. This is important so controller-runtime doesn't wait 30s when an error occurs during start, and we can error out straight away.

```
2021-07-01T12:59:15.168189Z	error	klog	manager "msg"="error received after stop sequence was engaged" "error"="context canceled"  
Error: failed to fetch initial serving certificate: failed to sign serving certificate: failed to wait for CertificateRequest istio-system/istio-csr-656xs to be signed: created CertificateRequest has been unexpectedly deleted
```

/assign @irbekrm 