### PR TITLE
Adds .app.tls.istiodCertificateDuration helm field as value to istiod's certificate.spec.,duration

### DIFF
--- a/deploy/charts/istio-csr/Chart.yaml
+++ b/deploy/charts/istio-csr/Chart.yaml
@@ -13,4 +13,4 @@ sources:
 - https://github.com/cert-manager/istio-csr
 
 appVersion: v0.2.0
-version: v0.2.0
+version: v0.2.1

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -40,7 +40,7 @@ A Helm chart for istio-csr
 | app.server.serving.address | string | `"0.0.0.0"` | Container address to serve istio-csr gRPC service. |
 | app.server.serving.port | int | `6443` | Container port to serve istio-csr gRPC service. |
 | app.tls.certificateDNSNames | list | `["cert-manager-istio-csr.cert-manager.svc"]` | The DNS names to request for the server's serving certificate which is presented to istio-agents. istio-agents must route to istio-csr using one of these DNS names. |
-| app.tls.certificateDuration | string | `"1h"` | Requested duration of gRPC serving certificate. Will be automatically renewed. Based on NIST 800-204A recommendations (SM-DR13). https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf cert-manager does not allow a duration on Certificates less than 1 hour. |
+| app.tls.certificateDuration | string | `"1h"` | Requested duration of gRPC serving certificate and mounted istiod certificate. Will be automatically renewed. Based on NIST 800-204A recommendations (SM-DR13). https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf cert-manager does not allow a duration on Certificates less than 1 hour. |
 | app.tls.rootCAFile | string | `nil` | An optional file location to a PEM encoded root CA that the root CA ConfigMap in all namespaces will be populated with. If empty, the CA returned from cert-manager for the serving certificate will be used. |
 | app.tls.trustDomain | string | `"cluster.local"` | The Istio cluster's trust domain. |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on Deployment. |

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -1,6 +1,6 @@
 # cert-manager-istio-csr
 
-![Version: v0.2.0](https://img.shields.io/badge/Version-v0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+![Version: v0.2.1](https://img.shields.io/badge/Version-v0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 A Helm chart for istio-csr
 
@@ -40,7 +40,8 @@ A Helm chart for istio-csr
 | app.server.serving.address | string | `"0.0.0.0"` | Container address to serve istio-csr gRPC service. |
 | app.server.serving.port | int | `6443` | Container port to serve istio-csr gRPC service. |
 | app.tls.certificateDNSNames | list | `["cert-manager-istio-csr.cert-manager.svc"]` | The DNS names to request for the server's serving certificate which is presented to istio-agents. istio-agents must route to istio-csr using one of these DNS names. |
-| app.tls.certificateDuration | string | `"1h"` | Requested duration of gRPC serving certificate and mounted istiod certificate. Will be automatically renewed. Based on NIST 800-204A recommendations (SM-DR13). https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf cert-manager does not allow a duration on Certificates less than 1 hour. |
+| app.tls.certificateDuration | string | `"1h"` | Requested duration of gRPC serving certificate. Will be automatically renewed. Based on NIST 800-204A recommendations (SM-DR13). https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf |
+| app.tls.istiodCertificateDuration | string | `"1h"` | Requested duration of istio's Certificate. Will be automatically renewed. Based on NIST 800-204A recommendations (SM-DR13). https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf Warning: cert-manager does not allow a duration on Certificates less than 1 hour. |
 | app.tls.rootCAFile | string | `nil` | An optional file location to a PEM encoded root CA that the root CA ConfigMap in all namespaces will be populated with. If empty, the CA returned from cert-manager for the serving certificate will be used. |
 | app.tls.trustDomain | string | `"cluster.local"` | The Istio cluster's trust domain. |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on Deployment. |

--- a/deploy/charts/istio-csr/templates/certificate.yaml
+++ b/deploy/charts/istio-csr/templates/certificate.yaml
@@ -13,7 +13,7 @@ spec:
   # recommendations (SM-DR13).
   # https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf
   # cert-manager does not allow a duration on Certificates of less that 1 hour.
-  duration: 1h
+  duration: {{ .Values.app.tls.certificateDuration }}
   renewBefore: 30m
   privateKey:
     rotationPolicy: Always

--- a/deploy/charts/istio-csr/templates/certificate.yaml
+++ b/deploy/charts/istio-csr/templates/certificate.yaml
@@ -12,8 +12,9 @@ spec:
   # Here we use a duration of 1 hour by default based on NIST 800-204A
   # recommendations (SM-DR13).
   # https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf
-  # cert-manager does not allow a duration on Certificates of less that 1 hour.
-  duration: {{ .Values.app.tls.certificateDuration }}
+  # Warning: cert-manager does not allow a duration on Certificates of less
+  # than 1 hour.
+  duration: {{ .Values.app.tls.istiodCertificateDuration }}
   renewBefore: 30m
   privateKey:
     rotationPolicy: Always

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -48,7 +48,6 @@ spec:
           - "--serving-certificate-dns-names={{ . }}"
         {{- end  }}
           - "--serving-certificate-duration={{.Values.app.tls.certificateDuration}}"
-          - "--serving-certificate-duration={{.Values.app.tls.certificateDuration}}"
           - "--trust-domain={{.Values.app.tls.trustDomain}}"
 
           # server

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -71,12 +71,18 @@ app:
     # of these DNS names.
     certificateDNSNames:
     - cert-manager-istio-csr.cert-manager.svc
-    # -- Requested duration of gRPC serving certificate and mounted istiod
-    # certificate. Will be automatically renewed.
+    # -- Requested duration of gRPC serving certificate. Will be automatically
+    # renewed.
     # Based on NIST 800-204A recommendations (SM-DR13).
     # https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf
-    # cert-manager does not allow a duration on Certificates less than 1 hour.
     certificateDuration: 1h
+    # -- Requested duration of istio's Certificate. Will be automatically
+    # renewed.
+    # Based on NIST 800-204A recommendations (SM-DR13).
+    # https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf
+    # Warning: cert-manager does not allow a duration on Certificates less than
+    # 1 hour.
+    istiodCertificateDuration: 1h
 
   server:
     # -- The istio cluster ID to verify incoming CSRs.

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -71,7 +71,8 @@ app:
     # of these DNS names.
     certificateDNSNames:
     - cert-manager-istio-csr.cert-manager.svc
-    # -- Requested duration of gRPC serving certificate. Will be automatically renewed.
+    # -- Requested duration of gRPC serving certificate and mounted istiod
+    # certificate. Will be automatically renewed.
     # Based on NIST 800-204A recommendations (SM-DR13).
     # https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf
     # cert-manager does not allow a duration on Certificates less than 1 hour.


### PR DESCRIPTION
This PR enables setting the istiod's `certificate.spec.duration` field using the helm field `app.tls.istiodCertificateDuration`.

The Helm version has been increased to prepare a new Helm Chart release. 

> Note that this is the first time the Helm Chart version will diversion from the `istio-csr` image version.

/assign @irbekrm 
fixes #81 