### PR TITLE
Allows istio revisions to be configurable from helm chart

### DIFF
--- a/deploy/charts/istio-csr/templates/certificate.yaml
+++ b/deploy/charts/istio-csr/templates/certificate.yaml
@@ -5,9 +5,18 @@ metadata:
   namespace: istio-system
 spec:
   dnsNames:
+  {{- if .Values.app.istio.revisions }}
+  {{- $revisions := dict -}}
+  {{- range $revision := .Values.app.istio.revisions -}}
+  {{- if eq $revision "default" }}{{ $revision = "" }}{{ end }}
+  {{- if ne $revision "" }}{{ $revision = print "-" $revision }}{{ end }}
+  - istiod{{$revision}}.istio-system.svc
+  {{- end }}
+  {{- else }}
   - istiod.istio-system.svc
+  {{- end }}
   uris:
-    - spiffe://cluster.local/ns/istio-system/sa/istiod-service-account
+  - spiffe://{{.Values.app.tls.trustDomain}}/ns/istio-system/sa/istiod-service-account
   secretName: istiod-tls
   # Here we use a duration of 1 hour by default based on NIST 800-204A
   # recommendations (SM-DR13).

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -99,6 +99,10 @@ app:
       # -- Container port to serve istio-csr gRPC service.
       port: 6443
 
+  istio:
+    # -- The istio revisions that are currently installed in the cluster.
+    revisions: []
+
   controller:
     leaderElectionNamespace: istio-system
     # -- Name of ConfigMap that should contain the root CA in all namespaces.


### PR DESCRIPTION
Signed-off-by: joshvanl <vleeuwenjoshua@gmail.com>

This PR expose the `app.istio.revisions` helm variable which modifies the DNS values which are present on the istiod Certificate. This allows for istio meshes which are running multiple revisions to still serve istiod correctly.

A new helm chart should be released once this is merged.

/assign @irbekrm 
/cc @keithmattix 
fixes #86 
