### PR TITLE
Ensure that the watcher returns a non-nil object before decoding

### DIFF
--- a/pkg/certmanager/certmanager_test.go
+++ b/pkg/certmanager/certmanager_test.go
@@ -422,15 +422,8 @@ func Test_waitForCertificateRequest(t *testing.T) {
 				return client.CertmanagerV1().CertificateRequests(gen.DefaultTestNamespace)
 			},
 
-			expResult: gen.CertificateRequest("test-cr",
-				gen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
-					Type:   cmapi.CertificateRequestConditionReady,
-					Status: cmmeta.ConditionFalse,
-					Reason: "random condition",
-				}),
-			),
-
-			expErr: true,
+			expResult: gen.CertificateRequest("test-cr"),
+			expErr:    true,
 		},
 	}
 


### PR DESCRIPTION
In some strange circumstances the watcher may return a nil object, as should [here](https://github.com/cert-manager/istio-csr/issues/89#issuecomment-913235885).

This PR fixes that by ensuring the watcher object is not nil before decoding.

/assign @irbekrm 
/release-note-none
/kind bug