### PR TITLE
Change context root to use controller-runtime signal handler

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,46 +17,20 @@ limitations under the License.
 package main
 
 import (
-	"context"
-	"fmt"
 	"os"
-	"os/signal"
-	"syscall"
 
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/cert-manager/istio-csr/cmd/app"
 )
 
 func main() {
-	ctx := signalHandler()
+	ctx := signals.SetupSignalHandler()
 	cmd := app.NewCommand(ctx)
 
 	if err := cmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		klog.ErrorS(err, "error running cert-manager-istio-csr")
 		os.Exit(1)
 	}
-}
-
-func signalHandler() context.Context {
-	ctx, cancel := context.WithCancel(context.Background())
-	ch := make(chan os.Signal, 2)
-	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
-
-	go func() {
-		sig := <-ch
-
-		cancel()
-
-		for i := 0; i < 3; i++ {
-			klog.Warningf("received signal %s, shutting down gracefully...", sig)
-			sig = <-ch
-		}
-
-		klog.Errorf("received signal %s, force closing", sig)
-
-		os.Exit(1)
-	}()
-
-	return ctx
 }


### PR DESCRIPTION
Replace our signal handler with the fuller featured controller-runtime one.

/kind cleanup
/assign @irbekrm 

```release-note
NONE
```