### PR TITLE
Root CA file watcher

### DIFF
--- a/pkg/controller/configmap.go
+++ b/pkg/controller/configmap.go
@@ -111,7 +111,7 @@ func AddConfigMapController(ctx context.Context, log logr.Logger, opts Options) 
 
 		// If the CA roots change then reconcile all ConfigMaps
 		Watches(&source.Channel{Source: c.tls.SubscribeRootCAsEvent()}, handler.EnqueueRequestsFromMapFunc(
-			func(obj client.Object) []reconcile.Request {
+			func(_ client.Object) []reconcile.Request {
 				var namespaceList corev1.NamespaceList
 				if err := c.lister.List(ctx, &namespaceList); err != nil {
 					c.log.Error(err, "failed to list namespaces, exiting...")
@@ -208,7 +208,7 @@ func (c *configmap) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resul
 	}
 
 	if updateNeeded {
-		log.V(3).Info("updating ConfigMap")
+		log.Info("updating ConfigMap data")
 		return ctrl.Result{}, c.client.Update(ctx, &configMap)
 	}
 

--- a/pkg/controller/configmap.go
+++ b/pkg/controller/configmap.go
@@ -152,8 +152,7 @@ func (c *configmap) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resul
 		return ctrl.Result{}, nil
 	}
 
-	rootCAsPEMBytes, _ := c.tls.RootCAs()
-	rootCAsPEM := string(rootCAsPEMBytes)
+	rootCAsPEM := string(c.tls.RootCAs().PEM)
 
 	// Check ConfigMap exists, and has the correct data.
 	var configMap corev1.ConfigMap

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -88,7 +88,7 @@ func New(log logr.Logger, restConfig *rest.Config, cm certmanager.Signer, tls tl
 
 	return &Server{
 		opts:   opts,
-		log:    log.WithName("grpc_server").WithValues("serving_addr", opts.ServingAddress),
+		log:    log.WithName("grpc-server").WithValues("serving-addr", opts.ServingAddress),
 		auther: auther,
 		cm:     cm,
 		tls:    tls,
@@ -230,10 +230,10 @@ func (s *Server) parseCertificateBundle(bundle certmanager.Bundle) ([]string, er
 		intermediatePool.AddCert(intermediate)
 	}
 
-	rootCAsPEM, rootCAsPool := s.tls.RootCAs()
+	rootCAs := s.tls.RootCAs()
 	opts := x509.VerifyOptions{
 		Intermediates: intermediatePool,
-		Roots:         rootCAsPool,
+		Roots:         rootCAs.CertPool,
 		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 	}
 	if _, err := respCerts[0].Verify(opts); err != nil {
@@ -250,5 +250,5 @@ func (s *Server) parseCertificateBundle(bundle certmanager.Bundle) ([]string, er
 		certChain = append(certChain, string(certEncoded))
 	}
 
-	return append(certChain, string(rootCAsPEM)), nil
+	return append(certChain, string(rootCAs.PEM)), nil
 }

--- a/pkg/tls/rootca/rootca.go
+++ b/pkg/tls/rootca/rootca.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rootca
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+)
+
+// RootCAs is a Root CAs bundle that contains raw PEM encoded CAs, as well as
+// their x509.CertPool encoding.
+type RootCAs struct {
+	// PEM is the raw PEM encoding of the CA certificates.
+	PEM []byte
+
+	// CertPool is the x509.CertPool encoding of the CA certificates.
+	CertPool *x509.CertPool
+}
+
+// watcher is used for loading and watching a file that contains a root CAs
+// bundle.
+type watcher struct {
+	log logr.Logger
+
+	filepath   string
+	rootCAsPEM []byte
+	syncPeriod time.Duration
+}
+
+// Watch watches the given filepath for changes, and writes to the returned
+// channel the new state when it changes. The first event is the initial state
+// of the root CAs file.
+func Watch(ctx context.Context, log logr.Logger, filepath string) (<-chan RootCAs, error) {
+	return (&watcher{
+		log:        log.WithName("root-ca-watcher").WithValues("file", filepath),
+		filepath:   filepath,
+		syncPeriod: time.Second * 10,
+	}).start(ctx)
+}
+
+// start will start the watcher. First RootCAs channel event is the first
+// initial file state.
+func (w watcher) start(ctx context.Context) (<-chan RootCAs, error) {
+	broadcastChan := make(chan RootCAs)
+
+	w.log.Info("loading root CAs bundle")
+	rootCAs, err := w.loadRootCAsFile()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load root CA bundle: %w", err)
+	}
+
+	go func() {
+		w.log.Info("starting root CAs file watcher")
+		timer := time.NewTicker(w.syncPeriod)
+		defer timer.Stop()
+
+		// Send initial root CAs state
+		broadcastChan <- *rootCAs
+		w.rootCAsPEM = rootCAs.PEM
+
+		for {
+			select {
+			case <-ctx.Done():
+				w.log.Info("closing root CAs file watcher")
+				return
+
+			case <-timer.C:
+				w.log.V(3).Info("checking for root CA changes on file")
+
+				rootCAs, err := w.loadRootCAsFile()
+				if err != nil {
+					w.log.Error(err, "failed to load root CAs file")
+				}
+
+				if rootCAs != nil {
+					w.log.Info("root CAs changed on file, broadcasting update")
+					w.rootCAsPEM = rootCAs.PEM
+					broadcastChan <- *rootCAs
+				}
+			}
+		}
+	}()
+
+	return broadcastChan, nil
+}
+
+// loadRootCAsFile will read the root CAs from the configured file, and if
+// changed from the previous state, will return the updated root CAs. Will
+// return nil if there has been no state change.
+func (w *watcher) loadRootCAsFile() (*RootCAs, error) {
+	rootCAsPEM, err := os.ReadFile(w.filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read root CAs certificate file %q: %w", w.filepath, err)
+	}
+
+	// If the root CAs PEM hasn't changed, return nil
+	if bytes.Equal(rootCAsPEM, w.rootCAsPEM) {
+		return nil, nil
+	}
+
+	w.log.Info("updating root CAs from file")
+
+	rootCAsCerts, err := pki.DecodeX509CertificateChainBytes(rootCAsPEM)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode root CAs in certificate file %q: %w", w.filepath, err)
+	}
+
+	rootCAsPool := x509.NewCertPool()
+	for _, rootCert := range rootCAsCerts {
+		rootCAsPool.AddCert(rootCert)
+	}
+
+	return &RootCAs{rootCAsPEM, rootCAsPool}, nil
+}

--- a/pkg/tls/rootca/rootca_test.go
+++ b/pkg/tls/rootca/rootca_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rootca
+
+import (
+	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/klog/v2/klogr"
+)
+
+func Test_Watch(t *testing.T) {
+	filepath := filepath.Join(t.TempDir(), "test-cert")
+	rootCAs1 := genRootCAs(t)
+	rootCAs2 := genRootCAs(t)
+
+	t.Log("writing first root CA PEM to file")
+	if err := os.WriteFile(filepath, rootCAs1.PEM, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	w := watcher{
+		log:        klogr.New(),
+		filepath:   filepath,
+		syncPeriod: time.Millisecond * 10,
+	}
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	t.Log("starting watcher")
+	rootCAsChan, err := w.start(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("ensuring the same root CA PEM is returned from watcher")
+	env1 := <-rootCAsChan
+	assert.Equal(t, rootCAs1.PEM, env1.PEM)
+	assert.Equal(t, rootCAs1.CertPool.Subjects(), env1.CertPool.Subjects())
+
+	t.Log("writing a different root CAs PEM to file")
+	if err := os.WriteFile(filepath, rootCAs2.PEM, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("ensuring the second root CA PEM is returned from watcher")
+	env2 := <-rootCAsChan
+	assert.Equal(t, rootCAs2.PEM, env2.PEM)
+	assert.Equal(t, rootCAs2.CertPool.Subjects(), env2.CertPool.Subjects())
+}
+
+func Test_loadRootCAsFile(t *testing.T) {
+	rootCAs := genRootCAs(t)
+
+	tests := map[string]struct {
+		filepath           func(t *testing.T, dir string) string
+		existingRootCAsPEM []byte
+		expRootCAs         *RootCAs
+		expErr             bool
+	}{
+		"if the filepath doesn't exist, should error": {
+			filepath:           func(t *testing.T, dir string) string { return filepath.Join(dir, "doesnt-exist") },
+			existingRootCAsPEM: nil,
+			expRootCAs:         nil,
+			expErr:             true,
+		},
+		"if the data hasn't changed, return nil": {
+			filepath: func(t *testing.T, dir string) string {
+				path := filepath.Join(dir, "test")
+				if err := os.WriteFile(path, []byte("root-certs"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			existingRootCAsPEM: []byte("root-certs"),
+			expRootCAs:         nil,
+			expErr:             false,
+		},
+		"if new root cert cannot be decoded, return error": {
+			filepath: func(t *testing.T, dir string) string {
+				path := filepath.Join(dir, "test")
+				if err := os.WriteFile(path, []byte("new-root-certs"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			existingRootCAsPEM: []byte("root-certs"),
+			expRootCAs:         nil,
+			expErr:             true,
+		},
+		"return new cert if it changes": {
+			filepath: func(t *testing.T, dir string) string {
+				path := filepath.Join(dir, "test")
+				if err := os.WriteFile(path, rootCAs.PEM, 0644); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			existingRootCAsPEM: []byte("root-certs"),
+			expRootCAs:         &RootCAs{rootCAs.PEM, rootCAs.CertPool},
+			expErr:             false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			w := &watcher{
+				log:        klogr.New(),
+				rootCAsPEM: test.existingRootCAsPEM,
+				filepath:   test.filepath(t, t.TempDir()),
+			}
+
+			rootCA, err := w.loadRootCAsFile()
+			assert.Equalf(t, test.expErr, err != nil, "%v", err)
+			if test.expRootCAs == nil {
+				assert.Nil(t, rootCA)
+			} else {
+				assert.Equal(t, test.expRootCAs.PEM, rootCA.PEM)
+				assert.Equal(t, test.expRootCAs.CertPool.Subjects(), rootCA.CertPool.Subjects())
+			}
+		})
+	}
+}
+
+func genRootCAs(t *testing.T) RootCAs {
+	rootPK, err := pki.GenerateEd25519PrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootCert := &x509.Certificate{
+		Version:               2,
+		BasicConstraintsValid: true,
+		SerialNumber:          big.NewInt(0),
+		Subject: pkix.Name{
+			CommonName: "root-ca",
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Minute),
+		KeyUsage:  x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		PublicKey: rootPK.Public(),
+		IsCA:      true,
+	}
+	rootCertPEM, rootCert, err := pki.SignCertificate(rootCert, rootCert, rootPK.Public(), rootPK)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootPool := x509.NewCertPool()
+	rootPool.AddCert(rootCert)
+	return RootCAs{rootCertPEM, rootPool}
+}

--- a/pkg/tls/rootca/rootca_test.go
+++ b/pkg/tls/rootca/rootca_test.go
@@ -41,17 +41,11 @@ func Test_Watch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	w := watcher{
-		log:        klogr.New(),
-		filepath:   filepath,
-		syncPeriod: time.Millisecond * 10,
-	}
-
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
 	t.Log("starting watcher")
-	rootCAsChan, err := w.start(ctx)
+	rootCAsChan, err := Watch(ctx, klogr.New(), filepath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -139,6 +139,10 @@ func (p *Provider) Start(ctx context.Context) error {
 				case rootCAs := <-rootCAsChan:
 					p.lock.Lock()
 					p.rootCAs = rootCAs
+					// Broadcast update to subscribers
+					for i := range p.subscriptions {
+						go func(i int) { p.subscriptions[i] <- event.GenericEvent{} }(i)
+					}
 					p.lock.Unlock()
 				}
 			}


### PR DESCRIPTION
Branched from #99  which should be merged first.

This PR introduces the `rootca` tls subpackage. If a root CAs file is defined, this package will watch for changes to this file and broadcast when it has changed. This is then used by the server and controller to distribute the changed CA roots without needed a  full restart.

/assign @irbekrm 

```release-note
NONE
```