### PR TITLE
Ensure that closed watch is dropped

### DIFF
--- a/pkg/certmanager/certmanager.go
+++ b/pkg/certmanager/certmanager.go
@@ -185,12 +185,14 @@ func (m *manager) waitForCertificateRequest(ctx context.Context, log logr.Logger
 		log.V(3).Info("waiting for CertificateRequest to become ready")
 
 		for {
-			w := <-watcher.ResultChan()
+			w, ok := <-watcher.ResultChan()
+			if !ok {
+				return cr, errors.New("watcher channel closed")
+			}
 			if w.Type == watch.Deleted {
 				return cr, errors.New("created CertificateRequest has been unexpectedly deleted")
 			}
 
-			var ok bool
 			cr, ok = w.Object.(*cmapi.CertificateRequest)
 			if !ok {
 				log.Error(nil, "got unexpected object response from watcher", "object", w.Object)


### PR DESCRIPTION
I ran into an issue whilst being in a state where there were some upgrades and cert-manager wasn't functioning and didn't approve the istio-csr's serving CR for a while. istio-csr got stuck [here](https://github.com/cert-manager/istio-csr/blob/main/pkg/certmanager/certmanager.go#L196) and didn't recover after the CR got approved.

I can no longer reproduce this, but I think what happened is that the channel got closed, which seems to be something to guard against, see related chats [here](https://kubernetes.slack.com/archives/C0EG7JC6T/p1582204630405500) and [here](https://kubernetes.slack.com/archives/C0EG7JC6T/p1612532880101800).

See logs from the error state (CR being approved yet istio-csr does not recover):
```
2021-10-24T08:16:27.934901Z     error   klog    cert-manager "msg"="got unexpected object response from watcher" "error"=null "identity"="istio-csr-serving" "name"="istio-csr-jxjm7" "namespace"="istio-system" "object"=null
2021-10-24T08:16:27.935089Z     error   klog    cert-manager "msg"="got unexpected object response from watcher" "error"=null "identity"="istio-csr-serving" "name"="istio-csr-jxjm7" "namespace"="istio-system" "object"=null
2021-10-24T08:16:27.935268Z     error   klog    cert-manager "msg"="got unexpected object response from watcher" "error"=null "identity"="istio-csr-serving" "name"="istio-csr-jxjm7" "namespace"="istio-system" "object"=null
2021-10-24T08:16:27.935482Z     error   klog    cert-manager "msg"="got unexpected object response from watcher" "error"=null "identity"="istio-csr-serving" "name"="istio-csr-jxjm7" "namespace"="istio-system" "object"=null
2021-10-24T08:16:27.935818Z     error   klog    cert-manager "msg"="got unexpected object response from watcher" "error"=null "identity"="istio-csr-serving" "name"="istio-csr-jxjm7" "namespace"="istio-system" "object"=null
irbe@istio-csr$ k get cr -n istio-system
NAME                    APPROVED   DENIED   READY   ISSUER            REQUESTOR                                         AGE
ca-for-istio-ca-rn8gb   True                True    ca-for-istio-ca   system:serviceaccount:cert-manager:cert-manager   28m
istio-csr-jxjm7         True                True    istio-ca                                                            116m
istiod-dm2rt            True                True    istio-ca          system:serviceaccount:cert-manager:cert-manager   28m
```


Signed-off-by: irbekrm <irbekrm@gmail.com>