### PR TITLE
A service isn't a requirement for the servicemonitor

### DIFF
--- a/deploy/charts/istio-csr/templates/metrics-servicemonitor.yaml
+++ b/deploy/charts/istio-csr/templates/metrics-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.app.metrics.service.enabled .Values.app.metrics.service.servicemonitor.enabled }}
+{{- if .Values.app.metrics.service.servicemonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
We shouldn't enforce the creation of the metrics service for the servicemonitor. The servicemonitor also picks up the default istio-csr service and when the metrics service is created, the metrics get picked up twice.

You can this in the following example on my cluster. I have 2 replicas and they get picked up twice
![Screenshot from 2021-11-26 09-14-17](https://user-images.githubusercontent.com/2216724/143556858-c08c3f1d-205b-4dfa-8bdb-e0c67810e02c.png)