### PR TITLE
docs: Add validation steps to getting started guide

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -12,6 +12,7 @@ You'll need the following tools installed on your machine:
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) and [docker](https://docs.docker.com/get-docker/) (if you're using kind)
 - [helm](https://helm.sh/docs/intro/install/)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
+- [jq](https://stedolan.github.io/jq/download/)
 
 In addition, Istio must not already be installed in your cluster. Installing istio-csr _after_ Istio is not supported.
 
@@ -130,4 +131,126 @@ istioctl install -f istio-install-config.yaml
 
 # If you're on OpenShift, you need a different profile:
 # istioctl install --set profile=openshift -f istio-install-config.yaml
+```
+
+## Validating Install
+
+The following steps are option but can be followed to validate everything is hooked correctly:
+
+1. Deploy a sample application & watch for `certificaterequests.cert-manager.io` resources
+2. Verify `cert-manager` logs for new `certificaterequests` and responses
+3. Verify the CA Endpoint being used in a `istio-proxy` sidecar container
+4. Using `istioctl` to fetch the certificate info for the `istio-proxy` container
+
+To see this all in action, lets deploy a very simple sample application from the
+[istio samples](https://github.com/istio/istio/tree/master/samples/httpbin).
+
+First set some environment variables whose values could be changed if needed:
+
+```shell
+# Set namespace for sample application
+export NAMESPACE=default
+# Set env var for the value of the app label in manifests
+export APP=httpbin
+# Grab the installed version of istio
+export ISTIO_VERSION=$(istioctl version -o json | jq -r '.meshVersion[0].Info.version')
+```
+
+We use the `default` namespace for simplicity, so let's label the namespace for istio injection:
+
+```shell
+kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite
+```
+
+In a separate terminal you should now follow the logs for `cert-manager`:
+
+```shell
+kubectl logs -n cert-manager $(kubectl get pods -n cert-manager -o jsonpath='{.items..metadata.name}' --selector app=cert-manager) --since 2m -f
+```
+
+In another separate terminal, lets watch the `istio-system` namespace for `certificaterequests`:
+
+```shell
+kubectl get certificaterequests.cert-manager.io -n istio-system -w
+```
+
+Now deploy the sample application `httpbin` in the labeled namespace. Note the use of a
+variable to match the manifest version to your installed istio version:
+
+```shell
+kubectl apply -n $NAMESPACE -f https://raw.githubusercontent.com/istio/istio/$ISTIO_VERSION/samples/httpbin/httpbin.yaml
+```
+
+You should see something similar to the output here for `certificaterequests`:
+
+```
+NAME             APPROVED   DENIED   READY   ISSUER       REQUESTOR                                         AGE
+istio-ca-74bnl   True                True    selfsigned   system:serviceaccount:cert-manager:cert-manager   2d2h
+istiod-w9zh6     True                True    istio-ca     system:serviceaccount:cert-manager:cert-manager   27m
+istio-csr-8ddcs                               istio-ca     system:serviceaccount:cert-manager:cert-manager-istio-csr   0s
+istio-csr-8ddcs   True                        istio-ca     system:serviceaccount:cert-manager:cert-manager-istio-csr   0s
+istio-csr-8ddcs   True                True    istio-ca     system:serviceaccount:cert-manager:cert-manager-istio-csr   0s
+istio-csr-8ddcs   True                True    istio-ca     system:serviceaccount:cert-manager:cert-manager-istio-csr   0s
+```
+
+The key request being `istio-csr-8ddcs` in our example output. You should then check your
+`cert-manager` log output for two log lines with this request being "Approved" and "Ready":
+
+```
+I0113 16:51:59.186482       1 conditions.go:261] Setting lastTransitionTime for CertificateRequest "istio-csr-8ddcs" condition "Approved" to 2022-01-13 16:51:59.186455713 +0000 UTC m=+3507.098466775
+I0113 16:51:59.258876       1 conditions.go:261] Setting lastTransitionTime for CertificateRequest "istio-csr-8ddcs" condition "Ready" to 2022-01-13 16:51:59.258837897 +0000 UTC m=+3507.170859959
+```
+
+You should now see the application is running with both the application container and the sidecar:
+
+```shell
+~ kubectl get pods -n $NAMESPACE
+NAME                       READY   STATUS    RESTARTS   AGE
+httpbin-74fb669cc6-559cg   2/2     Running   0           4m
+```
+
+To validate that the `istio-proxy` sidecar container has requested the certifiate from the correct
+service, check the container logs:
+
+```shell
+kubectl logs $(kubectl get pod -n $NAMESPACE -o jsonpath="{.items...metadata.name}" --selector app=$APP) -c istio-proxy
+```
+
+You should see some early logs similar to this example:
+
+```
+2022-01-13T16:51:58.495493Z	info	CA Endpoint cert-manager-istio-csr.cert-manager.svc:443, provider Citadel
+2022-01-13T16:51:58.495817Z	info	Using CA cert-manager-istio-csr.cert-manager.svc:443 cert with certs: var/run/secrets/istio/root-cert.pem
+2022-01-13T16:51:58.495941Z	info	citadelclient	Citadel client using custom root cert: cert-manager-istio-csr.cert-manager.svc:443
+```
+
+Finally we can inspect the certificate being used in memory by Envoy. This one liner should return you the certificate being used:
+
+```shell
+istioctl proxy-config secret $(kubectl get pods -n $NAMESPACE -o jsonpath='{.items..metadata.name}' --selector app=$APP) -o json | jq -r '.dynamicActiveSecrets[0].secret.tlsCertificate.certificateChain.inlineBytes' | base64 --decode | openssl x509 -text -noout
+```
+
+In particular look for the following sections:
+
+```
+    Signature Algorithm: ecdsa-with-SHA256
+        Issuer: O=cert-manager, O=cluster.local, CN=istio-ca
+        Validity
+            Not Before: Jan 13 16:51:59 2022 GMT
+            Not After : Jan 13 17:51:59 2022 GMT
+...
+            X509v3 Subject Alternative Name:
+                URI:spiffe://cluster.local/ns/default/sa/httpbin
+```
+
+You should see the relevant Trust Domain inside the Issuer. In the default case, it should be:
+`cluster.local` as above. Note that the SPIFFE URI may be different if you used a different
+namespace or application.
+
+## Clean up
+
+Assuming your running inside kind, you can simply remove the cluster:
+
+```shell
+kind delete cluster kind
 ```


### PR DESCRIPTION
I found it difficult to determine if my setup was correct. After some learning I decided to add validation steps where I could see istio-csr in use. Adding the steps here as generically as possible with istio's example applications.

Signed-off-by: Peter Fiddes <peter.fiddes@gmail.com>