### PR TITLE
Allow filtering namespaces to create the ConfigMap istio-ca-root-cert

### DIFF
--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -114,10 +114,10 @@ func NewCommand(ctx context.Context) *cobra.Command {
 
 			// Add the ConfigMap controller that propagates the root CAs.
 			if err := controller.AddConfigMapController(ctx, opts.Logr, controller.Options{
-				LeaderElectionNamespace: opts.Controller.LeaderElectionNamespace,
-				TLS:                     tls,
-				Manager:                 mgr,
-				NamespaceSelector:       opts.Controller.NamespaceSelector,
+				LeaderElectionNamespace:    opts.Controller.LeaderElectionNamespace,
+				TLS:                        tls,
+				Manager:                    mgr,
+				ConfigMapNamespaceSelector: opts.Controller.ConfigMapNamespaceSelector,
 			}); err != nil {
 				return fmt.Errorf("failed to add CA root controller: %w", err)
 			}

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -117,6 +117,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				LeaderElectionNamespace: opts.Controller.LeaderElectionNamespace,
 				TLS:                     tls,
 				Manager:                 mgr,
+				NamespaceSelector:       opts.Controller.NamespaceSelector,
 			}); err != nil {
 				return fmt.Errorf("failed to add CA root controller: %w", err)
 			}

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -24,7 +24,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
@@ -70,13 +69,9 @@ type OptionsController struct {
 	// held in.
 	LeaderElectionNamespace string
 
-	// NamespaceFilter is the filter applied to select the namespaces that
+	// NamespaceSelector is the selector to filter on the namespaces that
 	// receives the istio-root-ca ConfigMap
-	NamespaceFilter string
-
-	// NamespaceSelector is the parsed filter applied to select the namespaces that
-	// receives the istio-root-ca ConfigMap
-	NamespaceSelector labels.Selector
+	NamespaceSelector string
 }
 
 func New() *Options {
@@ -104,11 +99,6 @@ func (o *Options) Complete() error {
 	o.RestConfig, err = o.kubeConfigFlags.ToRESTConfig()
 	if err != nil {
 		return fmt.Errorf("failed to build kubernetes rest config: %s", err)
-	}
-
-	o.Controller.NamespaceSelector, err = labels.Parse(o.Controller.NamespaceFilter)
-	if err != nil {
-		return err
 	}
 
 	if len(o.TLS.RootCAsCertFile) == 0 {
@@ -236,7 +226,8 @@ func (o *Options) addControllerFlags(fs *pflag.FlagSet) {
 		"leader-election-namespace", "istio-system",
 		"Namespace to use for controller leader election.")
 
-	fs.StringVar(&o.Controller.NamespaceFilter,
-		"namespace-filter", "",
-		"Filter used to select the namespaces where the controller creates istio-ca-root-cert ConfigMap")
+	fs.StringVar(&o.Controller.NamespaceSelector,
+		"namespace-selector", "",
+		"Selector to filter on namespaces where the controller creates istio-ca-root-cert"+
+			" ConfigMap. Supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 }

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -69,9 +69,9 @@ type OptionsController struct {
 	// held in.
 	LeaderElectionNamespace string
 
-	// NamespaceSelector is the selector to filter on the namespaces that
+	// ConfigMapNamespaceSelector is the selector to filter on the namespaces that
 	// receives the istio-root-ca ConfigMap
-	NamespaceSelector string
+	ConfigMapNamespaceSelector string
 }
 
 func New() *Options {
@@ -226,8 +226,8 @@ func (o *Options) addControllerFlags(fs *pflag.FlagSet) {
 		"leader-election-namespace", "istio-system",
 		"Namespace to use for controller leader election.")
 
-	fs.StringVar(&o.Controller.NamespaceSelector,
-		"namespace-selector", "",
+	fs.StringVar(&o.Controller.ConfigMapNamespaceSelector,
+		"configmap-namespace-selector", "",
 		"Selector to filter on namespaces where the controller creates istio-ca-root-cert"+
 			" ConfigMap. Supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 }

--- a/pkg/controller/configmap.go
+++ b/pkg/controller/configmap.go
@@ -56,7 +56,7 @@ type Options struct {
 	Manager manager.Manager
 
 	// NamespaceSelector filters the namespace to creates the istio-ca-root-cert ConfigMap
-	NamespaceSelector string
+	ConfigMapNamespaceSelector string
 }
 
 // configmap is the controller that is responsible for ensuring that all
@@ -95,7 +95,7 @@ func AddConfigMapController(ctx context.Context, log logr.Logger, opts Options) 
 		return fmt.Errorf("failed to build non-cached client for ConfigMaps: %w", err)
 	}
 
-	namespaceSelector, err := labels.Parse(opts.NamespaceSelector)
+	namespaceSelector, err := labels.Parse(opts.ConfigMapNamespaceSelector)
 	if err != nil {
 		return fmt.Errorf("failed to parse namespace selector: %w", err)
 	}

--- a/pkg/controller/configmap.go
+++ b/pkg/controller/configmap.go
@@ -56,7 +56,7 @@ type Options struct {
 	Manager manager.Manager
 
 	// NamespaceSelector filters the namespace to creates the istio-ca-root-cert ConfigMap
-	NamespaceSelector labels.Selector
+	NamespaceSelector string
 }
 
 // configmap is the controller that is responsible for ensuring that all
@@ -95,12 +95,17 @@ func AddConfigMapController(ctx context.Context, log logr.Logger, opts Options) 
 		return fmt.Errorf("failed to build non-cached client for ConfigMaps: %w", err)
 	}
 
+	namespaceSelector, err := labels.Parse(opts.NamespaceSelector)
+	if err != nil {
+		return fmt.Errorf("failed to parse namespace selector: %w", err)
+	}
+
 	c := &configmap{
 		client:            noCacheClient,
 		lister:            opts.Manager.GetCache(),
 		log:               log.WithName("controller").WithName("configmap"),
 		tls:               opts.TLS,
-		namespaceSelector: opts.NamespaceSelector,
+		namespaceSelector: namespaceSelector,
 	}
 
 	return ctrl.NewControllerManagedBy(opts.Manager).


### PR DESCRIPTION
This MR adds a parameter to filter namespaces in which the ConfigMap istio-ca-root-cert is created.
This parameter is validate on Complete() in [options.go](cmd/app/options/options.go) and propagated to
the [controller](pkg/controller/configmap.go).

So, the user can configure istio-csr to create the istio-root-ca-cert ConfigMap only on namespaces labelled _istio-csr-injection=enabled_ by adding the command-line parameter _--namespace-selector=istio-csr-injection=enabled_