### PR TITLE
Test with cert-manager 1.7

### DIFF
--- a/hack/demo/deploy-demo.sh
+++ b/hack/demo/deploy-demo.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 K8S_NAMESPACE="${K8S_NAMESPACE:-istio-system}"
-CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-1.4.0}"
+CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-1.7.0}"
 ISTIO_AGENT_IMAGE="${CERT_MANAGER_ISTIO_AGENT_IMAGE:-quay.io/jetstack/cert-manager-istio-csr:canary}"
 KUBECTL_BIN="${KUBECTL_BIN:-./bin/kubectl}"
 HELM_BIN="${HELM_BIN:-./bin/helm}"


### PR DESCRIPTION
cert-manager 1.7.0 is released to let's use it in the E2E tests.