### PR TITLE
Add an ability to select nodes for istio-csr

### DIFF
--- a/deploy/charts/istio-csr/Chart.yaml
+++ b/deploy/charts/istio-csr/Chart.yaml
@@ -13,4 +13,4 @@ sources:
 - https://github.com/cert-manager/istio-csr
 
 appVersion: v0.4.0
-version: v0.4.1
+version: v0.4.2

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -20,6 +20,7 @@ istio-csr enables the use of cert-manager for issuing certificates in Istio serv
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| affinity | object | `{}` | Node affinity for pod assignment. |
 | app.certmanager.issuer.group | string | `"cert-manager.io"` | Issuer group name set on created CertificateRequests for both istio-csr's serving certificate and incoming gRPC CSRs. |
 | app.certmanager.issuer.kind | string | `"Issuer"` | Issuer kind set on created CertificateRequests for both istio-csr's serving certificate and incoming gRPC CSRs. |
 | app.certmanager.issuer.name | string | `"istio-ca"` | Issuer name set on created CertificateRequests for both istio-csr's serving certificate and incoming gRPC CSRs. |
@@ -48,10 +49,12 @@ istio-csr enables the use of cert-manager for issuing certificates in Istio serv
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on Deployment. |
 | image.repository | string | `"quay.io/jetstack/cert-manager-istio-csr"` | Target image repository. |
 | image.tag | string | `"v0.4.0"` | Target image version tag. |
+| nodeSelector | object | `{}` | Node labels for pod assignment. |
 | replicaCount | int | `1` | Number of replicas of istio-csr to run. |
 | resources | object | `{}` |  |
 | service.port | int | `443` | Service port to expose istio-csr gRPC service. |
 | service.type | string | `"ClusterIP"` | Service type to expose istio-csr gRPC service. |
+| tolerations | list | `[]` | Node tolerations for pod assignment. |
 | volumeMounts | list | `[]` | Optional extra volume mounts. Useful for mounting custom root CAs |
 | volumes | list | `[]` | Optional extra volumes. Useful for mounting custom root CAs |
 

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -15,6 +15,18 @@ spec:
         app: {{ include "cert-manager-istio-csr.name" . }}
     spec:
       serviceAccountName: {{ include "cert-manager-istio-csr.name" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ include "cert-manager-istio-csr.name" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -141,3 +141,27 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+# expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
+# for example:
+#   affinity:
+#     nodeAffinity:
+#      requiredDuringSchedulingIgnoredDuringExecution:
+#        nodeSelectorTerms:
+#        - matchExpressions:
+#          - key: foo.bar.com/role
+#            operator: In
+#            values:
+#            - master
+affinity: {}
+
+# expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core
+# for example:
+#   tolerations:
+#   - key: foo.bar.com/role
+#     operator: Equal
+#     value: master
+#     effect: NoSchedule
+tolerations: []
+
+nodeSelector: {}


### PR DESCRIPTION
Adding an ability to define nodes for `istio-csr` the same way, `cert-manager` Helm chart does. This PR adds configuration for:
* [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
* [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)
* [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
So, a user can specify nodes to run `istio-csr`.

Signed-off-by: Yurii Rochniak <yurii.rochniak@n26.com>