### PR TITLE
Use updated helm chart apiVersion for helm v3 support

### DIFF
--- a/deploy/charts/istio-csr/Chart.yaml
+++ b/deploy/charts/istio-csr/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 
 name: cert-manager-istio-csr
 type: application


### PR DESCRIPTION
Signed-off-by: Nitish Krishna Kaveri <nitish.krishna@getcruise.com>

Trying to install istio-csr chart via [helmfile](https://github.com/helmfile/helmfile) results in the following linting error:
```
==> Linting /tmp/helmfile2642110333/cert-manager/cert-manager-istio-csr/cert-manager-istio-csr/cert-manager-istio-csr/v0.4.2/cert-manager-istio-csr
--
[ERROR] Chart.yaml: chart type is not valid in apiVersion 'v1'. It is valid in apiVersion 'v2'
```
From [docs](https://helm.sh/docs/topics/charts/#the-apiversion-field):
```
The apiVersion Field
The apiVersion field should be v2 for Helm charts that require at least Helm 3. Charts supporting previous Helm versions have an apiVersion set to v1 and are still installable by Helm 3.

Changes from v1 to v2:

A dependencies field defining chart dependencies, which were located in a separate requirements.yaml file for v1 charts (see Chart Dependencies).
The type field, discriminating application and library charts (see Chart Types).
```