### PR TITLE
fix: metrics service labels

### DIFF
--- a/deploy/charts/istio-csr/templates/metrics-service.yaml
+++ b/deploy/charts/istio-csr/templates/metrics-service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ include "cert-manager-istio-csr.name" . }}-metrics
   labels:
-    app: {{ include "cert-manager-istio-csr.name" . }}
+    app: {{ include "cert-manager-istio-csr.name" . }}-metrics
 {{ include "cert-manager-istio-csr.labels" . | indent 4 }}
 spec:
   type: {{ .Values.app.metrics.service.type }}

--- a/deploy/charts/istio-csr/templates/metrics-servicemonitor.yaml
+++ b/deploy/charts/istio-csr/templates/metrics-servicemonitor.yaml
@@ -14,7 +14,7 @@ spec:
   jobLabel: {{ include "cert-manager-istio-csr.name" . }}
   selector:
     matchLabels:
-      app: {{ include "cert-manager-istio-csr.name" . }}
+      app: {{ include "cert-manager-istio-csr.name" . }}-metrics
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}


### PR DESCRIPTION
Servicemonitor should have a selector that only matches service-metrics and not the app-service, in order to avoind adding each prometheus target twice.

fixes: https://github.com/cert-manager/istio-csr/issues/180