### PR TITLE
Update dockerfile golang version to match go.mod file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the istio-csr binary
-FROM docker.io/library/golang:1.17 as builder
+FROM docker.io/library/golang:1.18 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
go.mod file shows the Golang version as 1.18 but the Dockerfile Golang builder is 1.17.  Updating the Golang version in the Dockerfile to match to go.mod file.