### PR TITLE
Add the ability to ignore cluster scoped resources. 

### DIFF
--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -50,6 +50,7 @@ istio-csr enables the use of cert-manager for issuing certificates in Istio serv
 | app.tls.istiodPrivateKeySize | int | `2048` |  |
 | app.tls.rootCAFile | string | `nil` | An optional file location to a PEM encoded root CA that the root CA ConfigMap in all namespaces will be populated with. If empty, the CA returned from cert-manager for the serving certificate will be used. |
 | app.tls.trustDomain | string | `"cluster.local"` | The Istio cluster's trust domain. |
+| ignoreClusterResources | bool | `false` | Ignore creation of clusterscoped resources, ClusterRole and ClusterRolebinding. Useful in multitenant deployments. |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on Deployment. |
 | image.repository | string | `"quay.io/jetstack/cert-manager-istio-csr"` | Target image repository. |
 | image.tag | string | `"v0.5.0"` | Target image version tag. |

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -50,7 +50,7 @@ istio-csr enables the use of cert-manager for issuing certificates in Istio serv
 | app.tls.istiodPrivateKeySize | int | `2048` |  |
 | app.tls.rootCAFile | string | `nil` | An optional file location to a PEM encoded root CA that the root CA ConfigMap in all namespaces will be populated with. If empty, the CA returned from cert-manager for the serving certificate will be used. |
 | app.tls.trustDomain | string | `"cluster.local"` | The Istio cluster's trust domain. |
-| ignoreClusterResources | bool | `false` | Ignore creation of clusterscoped resources, ClusterRole and ClusterRolebinding. Useful in multitenant deployments. |
+| ignoreClusterResources | bool | `false` | Set this to true to ignore creation of clusterscoped resources, ClusterRole and ClusterRolebinding. Useful in multitenant deployments with multiple istio-csr deployments |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on Deployment. |
 | image.repository | string | `"quay.io/jetstack/cert-manager-istio-csr"` | Target image repository. |
 | image.tag | string | `"v0.5.0"` | Target image version tag. |

--- a/deploy/charts/istio-csr/templates/clusterrole.yaml
+++ b/deploy/charts/istio-csr/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.ignoreClusterResources }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -21,3 +22,4 @@ rules:
   - "tokenreviews"
   verbs:
   - "create"
+{{- end }}

--- a/deploy/charts/istio-csr/templates/clusterrolebinding.yaml
+++ b/deploy/charts/istio-csr/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.ignoreClusterResources }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -12,3 +13,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "cert-manager-istio-csr.name" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -12,6 +12,8 @@ image:
 # -- Optional secrets used for pulling the istio-csr container image.
 imagePullSecrets: []
 
+ignoreClusterResources: false
+
 service:
   # -- Service type to expose istio-csr gRPC service.
   type: ClusterIP

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -12,6 +12,7 @@ image:
 # -- Optional secrets used for pulling the istio-csr container image.
 imagePullSecrets: []
 
+# -- Set this to true to ignore creation of clusterscoped resources, ClusterRole and ClusterRolebinding. Useful in multitenant deployments with multiple istio-csr deployments
 ignoreClusterResources: false
 
 service:


### PR DESCRIPTION
These resources will generally be handled seperatly in a multitenant enviornment. This also gives the ability to control where the service account can create the configmaps, as clusterwide read/write on configmaps could be to broad access for security reasons.

Signed-off-by: Knut-Erik Johnsen <knut-erik.johnsen@klp.no>