### PR TITLE
Remove controller.rootCAConfigMapName from helm values

### DIFF
--- a/hack/demo/istio-csr-values.yaml
+++ b/hack/demo/istio-csr-values.yaml
@@ -41,9 +41,4 @@ app:
       address: 0.0.0.0
       port: 6443
 
-
-  controller:
-    rootCAConfigMapName: istio-ca-root-cert
-
-
 resources: {}

--- a/test/carotation/values/istio-csr-1.yaml
+++ b/test/carotation/values/istio-csr-1.yaml
@@ -24,10 +24,6 @@ app:
     rootCAFile: /var/run/secrets/istio-csr/ca.pem
     certificateDuration: 20s
 
-  controller:
-    rootCAConfigMapName: istio-ca-root-cert
-
-
 volumes:
 - name: istio-root-certs
   secret:

--- a/test/carotation/values/istio-csr-2.yaml
+++ b/test/carotation/values/istio-csr-2.yaml
@@ -24,10 +24,6 @@ app:
     rootCAFile: /var/run/secrets/istio-csr/ca.pem
     certificateDuration: 20s
 
-  controller:
-    rootCAConfigMapName: istio-ca-root-cert
-
-
 volumes:
 - name: istio-root-certs
   secret:


### PR DESCRIPTION
Signed-off-by: Jacek Ewertowski <jacek.ewertowski1@gmail.com>

The `app.controller.rootCAConfigMapName` value is not configurable since v0.3.0.