### PR TITLE
Update OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,4 @@
 approvers:
-- joshvanl
-- jakexks
-- SgtCoDFish
+- cm-maintainers
 reviewers:
-- joshvanl
-- SgtCoDFish
+- cm-maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,11 @@
+aliases:
+  cm-maintainers:
+    - munnerz
+    - joshvanl
+    - meyskens
+    - wallrj
+    - jakexks
+    - maelvls
+    - irbekrm
+    - sgtcodfish
+    - inteon


### PR DESCRIPTION
See https://www.kubernetes.dev/docs/guide/owners/ for more info.

Unfortunately, it is not possible to use a GH Teams in this OWNERS file:

> We use aliases for groups instead of GitHub Teams, because changes to GitHub Teams are not publicly auditable.
> - https://www.kubernetes.dev/docs/guide/owners/#owners_aliases

Instead, I created an OWNERS_ALIASES file that will have to be kept in-sync across all our repos.