### PR TITLE
Seperate Role permissions between leases for leader election and cert…

### DIFF
--- a/deploy/charts/istio-csr/templates/role.yaml
+++ b/deploy/charts/istio-csr/templates/role.yaml
@@ -17,16 +17,6 @@ rules:
   - "update"
   - "delete"
   - "watch"
-- apiGroups:
-  - "coordination.k8s.io"
-  resources:
-  - "leases"
-  verbs:
-  - "get"
-  - "create"
-  - "update"
-  - "watch"
-  - "list"
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["create"]

--- a/deploy/charts/istio-csr/templates/role_leases.yaml
+++ b/deploy/charts/istio-csr/templates/role_leases.yaml
@@ -1,0 +1,19 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+{{ include "cert-manager-istio-csr.labels" . | indent 4 }}
+  name: {{ include "cert-manager-istio-csr.name" . }}-leases
+  namespace: {{ .Values.app.controller.leaderElectionNamespace }}
+rules:
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - "leases"
+  verbs:
+  - "get"
+  - "create"
+  - "update"
+  - "watch"
+  - "list"
+

--- a/deploy/charts/istio-csr/templates/rolebinding_leases.yaml
+++ b/deploy/charts/istio-csr/templates/rolebinding_leases.yaml
@@ -8,7 +8,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "cert-manager-istio-csr.name" . }}
+  name: {{ include "cert-manager-istio-csr.name" . }}-leases
 subjects:
 - kind: ServiceAccount
   name: {{ include "cert-manager-istio-csr.name" . }}

--- a/deploy/charts/istio-csr/templates/rolebinding_leases.yaml
+++ b/deploy/charts/istio-csr/templates/rolebinding_leases.yaml
@@ -1,0 +1,15 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "cert-manager-istio-csr.name" . }}-leases
+  namespace: {{ .Values.app.controller.leaderElectionNamespace }}
+  labels:
+{{ include "cert-manager-istio-csr.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "cert-manager-istio-csr.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "cert-manager-istio-csr.name" . }}
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Fixes #191 

* Fixes the configuration for the scenario where the leader election namespace is not the same as the cert-manager Issuer namespace.
* Most commonly arises when we are installing in a multi-tenant where Istio is not in istio-system namespace.
* For example, Istio can be installed with mesh1 as the default namespace, the issuer could still live in an istio-system or cert-manager namespace and the leader election namespace can be mesh1 or any other namespace if needed.


I've also checked and the events broadcaster thing needs to stay in the cert-manager namespace as it relates to certificate issuance/lifecycle events which are broadcast to that namespace by default.