### PR TITLE
Release v0.6.0-alpha.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ ARCH   ?= $(shell go env GOARCH)
 ISTIO_VERSION ?= 1.16.2
 K8S_VERSION ?= 1.26.1
 IMAGE_PLATFORMS ?= linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
+VERSION_TAG=v0.6.0-alpha.0
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
@@ -62,7 +63,11 @@ verify: test build ## tests and builds cert-manager-istio-csr
 # arguments to `--push`.
 .PHONY: image
 image: ## build docker image targeting all supported platforms
-	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/cert-manager-istio-csr:v0.5.0 --output type=oci,dest=./bin/cert-manager-istio-csr-oci .
+	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/cert-manager-istio-csr:$(VERSION_TAG) --output type=oci,dest=./bin/cert-manager-istio-csr-oci .
+
+.PHONY: package-chart
+package-chart: helm-docs
+	helm package deploy/charts/istio-csr
 
 .PHONY: clean
 clean: ## clean up created files

--- a/deploy/charts/istio-csr/Chart.yaml
+++ b/deploy/charts/istio-csr/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 sources:
 - https://github.com/cert-manager/istio-csr
 
-appVersion: v0.5.0
-version: v0.5.0
+appVersion: v0.6.0-alpha.0
+version: v0.6.0-alpha.0

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -1,6 +1,6 @@
 # cert-manager-istio-csr
 
-![Version: v0.5.0](https://img.shields.io/badge/Version-v0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5.0](https://img.shields.io/badge/AppVersion-v0.5.0-informational?style=flat-square)
+![Version: v0.6.0-alpha.0](https://img.shields.io/badge/Version-v0.6.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.0-alpha.0](https://img.shields.io/badge/AppVersion-v0.6.0--alpha.0-informational?style=flat-square)
 
 istio-csr enables the use of cert-manager for issuing certificates in Istio service meshes
 
@@ -52,7 +52,7 @@ istio-csr enables the use of cert-manager for issuing certificates in Istio serv
 | app.tls.trustDomain | string | `"cluster.local"` | The Istio cluster's trust domain. |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on Deployment. |
 | image.repository | string | `"quay.io/jetstack/cert-manager-istio-csr"` | Target image repository. |
-| image.tag | string | `"v0.5.0"` | Target image version tag. |
+| image.tag | string | `"v0.6.0-alpha.0"` | Target image version tag. |
 | imagePullSecrets | list | `[]` | Optional secrets used for pulling the istio-csr container image. |
 | nodeSelector | object | `{}` |  |
 | replicaCount | int | `1` | Number of replicas of istio-csr to run. |

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -5,7 +5,7 @@ image:
   # -- Target image repository.
   repository: quay.io/jetstack/cert-manager-istio-csr
   # -- Target image version tag.
-  tag: v0.5.0
+  tag: v0.6.0-alpha.0
   # -- Kubernetes imagePullPolicy on Deployment.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Plan to release v0.6.0 images, test with this branch locally and release v0.6.0 chart and image.