### PR TITLE
Add namespace values in Helm template

### DIFF
--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cert-manager-istio-csr.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "cert-manager-istio-csr.labels" . | indent 4 }}
 spec:

--- a/deploy/charts/istio-csr/templates/metrics-service.yaml
+++ b/deploy/charts/istio-csr/templates/metrics-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cert-manager-istio-csr.name" . }}-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "cert-manager-istio-csr.name" . }}-metrics
 {{ include "cert-manager-istio-csr.labels" . | indent 4 }}

--- a/deploy/charts/istio-csr/templates/metrics-servicemonitor.yaml
+++ b/deploy/charts/istio-csr/templates/metrics-servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "cert-manager-istio-csr.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "cert-manager-istio-csr.name" . }}
 {{ include "cert-manager-istio-csr.labels" . | indent 4 }}

--- a/deploy/charts/istio-csr/templates/service.yaml
+++ b/deploy/charts/istio-csr/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cert-manager-istio-csr.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "cert-manager-istio-csr.name" . }}
 {{ include "cert-manager-istio-csr.labels" . | indent 4 }}

--- a/deploy/charts/istio-csr/templates/serviceaccount.yaml
+++ b/deploy/charts/istio-csr/templates/serviceaccount.yaml
@@ -8,3 +8,4 @@ metadata:
   labels:
 {{ include "cert-manager-istio-csr.labels" . | indent 4 }}
   name: {{ include "cert-manager-istio-csr.name" . }}
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
By explicitly rendering the namespace values, we help users who `helm template` our Helm charts.