### PR TITLE
Use upstream images instead of custom built images

### DIFF
--- a/test/carotation/workloads/sleep.yaml
+++ b/test/carotation/workloads/sleep.yaml
@@ -61,7 +61,7 @@ spec:
       serviceAccountName: sleep
       containers:
       - name: sleep
-        image: quay.io/joshvanl_jetstack/curl
+        image: quay.io/curl/curl:latest
         command: ["/bin/sleep", "3650d"]
         imagePullPolicy: IfNotPresent
         volumeMounts:

--- a/test/e2e/manifests/httpbin.yaml
+++ b/test/e2e/manifests/httpbin.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       serviceAccountName: httpbin
       containers:
-      - image: quay.io/joshvanl_jetstack/httpbin:latest
+      - image: kennethreitz/httpbin:latest
         imagePullPolicy: IfNotPresent
         name: httpbin
         ports:

--- a/test/e2e/manifests/sleep.yaml
+++ b/test/e2e/manifests/sleep.yaml
@@ -51,7 +51,7 @@ spec:
       serviceAccountName: sleep
       containers:
       - name: sleep
-        image: quay.io/joshvanl_jetstack/curl
+        image: quay.io/curl/curl:latest
         command: ["/bin/sleep", "3650d"]
         imagePullPolicy: IfNotPresent
         volumeMounts:


### PR DESCRIPTION
replaces:
- `quay.io/joshvanl_jetstack/curl` with `quay.io/curl/curl:latest`
- `quay.io/joshvanl_jetstack/httpbin:latest` with `kennethreitz/httpbin:latest`