### PR TITLE
Upload junit and coverage results to ARTIFACTS folder

### DIFF
--- a/make/test-e2e.mk
+++ b/make/test-e2e.mk
@@ -74,6 +74,8 @@ test-e2e-deps: e2e-setup-istio
 ## @category Testing
 test-e2e: test-e2e-deps | kind-cluster $(NEEDS_GINKGO) $(NEEDS_KUBECTL)
 	$(GINKGO) \
+		--output-dir=$(ARTIFACTS) \
+		--junit-report=junit-go-e2e.xml \
 		./test/e2e/ \
 		-ldflags $(go_manager_ldflags) \
 		-- \

--- a/make/test-unit.mk
+++ b/make/test-unit.mk
@@ -15,11 +15,15 @@
 .PHONY: test-unit
 ## Unit tests
 ## @category Testing
-test-unit: | $(NEEDS_GOTESTSUM) $(NEEDS_ETCD) $(NEEDS_KUBE-APISERVER) $(NEEDS_KUBECTL)
+test-unit: | $(NEEDS_GOTESTSUM) $(NEEDS_GO) $(NEEDS_ETCD) $(NEEDS_KUBE-APISERVER) $(NEEDS_KUBECTL) $(ARTIFACTS)
 	KUBEBUILDER_ASSETS=$(CURDIR)/$(bin_dir)/tools \
 	$(GOTESTSUM) \
+		--junitfile=$(ARTIFACTS)/junit-go-e2e.xml \
+		-- \
+		-coverprofile=$(ARTIFACTS)/filtered.cov \
 		./cmd/... ./pkg/... \
 		-- \
 		-ldflags $(go_manager_ldflags) \
 		-test.timeout 2m \
-		-coverprofile cover.out
+
+	$(GO) tool cover -html=$(ARTIFACTS)/filtered.cov -o=$(ARTIFACTS)/filtered.html


### PR DESCRIPTION
Output junit reports to a file in the ARTIFACTS folder, so the tests show as a beautiful list in prow.

Also uploads coverage profile for the unit tests.