### PR TITLE
Set controller-runtime global logger

### DIFF
--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -73,6 +73,11 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("error creating kubernetes client: %s", err.Error())
 			}
 
+			// Set the controller-runtime global logger which is used by its internal
+			// logging (RuntimeLog, see link below).
+			// https://github.com/kubernetes-sigs/controller-runtime/blob/6747c42ce33966b0e77cac278c6b9087cc2f51c7/pkg/internal/log/log.go#L31
+			ctrl.SetLogger(opts.Logr)
+
 			mlog := opts.Logr.WithName("manager")
 			eventBroadcaster := record.NewBroadcaster()
 			eventBroadcaster.StartLogging(func(format string, args ...interface{}) { mlog.V(3).Info(fmt.Sprintf(format, args...)) })


### PR DESCRIPTION
To prevent `"[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed."` errors (even after passing a logger to the controller-runtime Manager options), we have to set it's global logger.
This logger is used to log internal messages (see https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/internal/log/log.go#L31).
An example of when this logger is used is when a healthz check fails: https://github.com/kubernetes-sigs/controller-runtime/blob/6747c42ce33966b0e77cac278c6b9087cc2f51c7/pkg/healthz/healthz.go#L60.

before:
```
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
...
```

after:
```
2024-01-22T13:43:45.904624Z     info    klog    "msg"="healthz check failed" "checker"="grpc_server" "error"="BOOM" "logger"="controller-runtime.healthz"
```