### PR TITLE
Use Helm template to generate image OCI path

### DIFF
--- a/deploy/charts/istio-csr/Chart.yaml
+++ b/deploy/charts/istio-csr/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 sources:
 - https://github.com/cert-manager/istio-csr
 
-appVersion: v0.7.1
-version: v0.7.1
+appVersion: v0.0.0
+version: v0.0.0

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -1,6 +1,6 @@
 # cert-manager-istio-csr
 
-![Version: v0.7.1](https://img.shields.io/badge/Version-v0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.7.1](https://img.shields.io/badge/AppVersion-v0.7.1-informational?style=flat-square)
+![Version: v0.0.0](https://img.shields.io/badge/Version-v0.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.0](https://img.shields.io/badge/AppVersion-v0.0.0-informational?style=flat-square)
 
 istio-csr enables the use of cert-manager for issuing certificates in Istio service meshes
 
@@ -53,9 +53,11 @@ istio-csr enables the use of cert-manager for issuing certificates in Istio serv
 | app.tls.istiodPrivateKeySize | int | `2048` |  |
 | app.tls.rootCAFile | string | `nil` | An optional file location to a PEM encoded root CA that the root CA ConfigMap in all namespaces will be populated with. If empty, the CA returned from cert-manager for the serving certificate will be used. |
 | app.tls.trustDomain | string | `"cluster.local"` | The Istio cluster's trust domain. |
-| image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on Deployment. |
-| image.repository | string | `"quay.io/jetstack/cert-manager-istio-csr"` | Target image repository. |
-| image.tag | string | `"v0.7.1"` | Target image version tag. |
+| image.digest | string | `nil` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.registry | string | `nil` |  |
+| image.repository | string | `"quay.io/jetstack/cert-manager-istio-csr"` |  |
+| image.tag | string | `nil` |  |
 | imagePullSecrets | list | `[]` | Optional secrets used for pulling the istio-csr container image. |
 | nodeSelector | object | `{}` |  |
 | replicaCount | int | `1` | Number of replicas of istio-csr to run. |

--- a/deploy/charts/istio-csr/templates/_helpers.tpl
+++ b/deploy/charts/istio-csr/templates/_helpers.tpl
@@ -25,3 +25,17 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Util function for generating the image URL based on the provided options.
+IMPORTANT: This function is standarized across all charts in the cert-manager GH organization.
+Any changes to this function should also be made in cert-manager, trust-manager, approver-policy, ...
+See https://github.com/cert-manager/cert-manager/issues/6329 for a list of linked PRs.
+*/}}
+{{- define "image" -}}
+{{- $defaultTag := index . 1 -}}
+{{- with index . 0 -}}
+{{- if .registry -}}{{ printf "%s/%s" .registry .repository }}{{- else -}}{{- .repository -}}{{- end -}}
+{{- if .digest -}}{{ printf "@%s" .digest }}{{- else -}}{{ printf ":%s" (default $defaultTag .tag) }}{{- end -}}
+{{- end }}
+{{- end }}

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ include "cert-manager-istio-csr.name" . }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ template "image" (tuple .Values.image $.Chart.AppVersion) }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.app.server.serving.port }}

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -2,11 +2,20 @@
 replicaCount: 1
 
 image:
-  # -- Target image repository.
+  # Target image repository.
   repository: quay.io/jetstack/cert-manager-istio-csr
-  # -- Target image version tag.
-  tag: v0.7.1
-  # -- Kubernetes imagePullPolicy on Deployment.
+  # Target image registry. Will be prepended to the target image repository if set.
+  registry:
+
+  # Target image version tag. Defaults to the chart's appVersion.
+  tag:
+
+  # Target image digest. Will override any tag if set.
+  # For example:
+  # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
+  digest:
+
+  # Kubernetes imagePullPolicy on Deployment.
   pullPolicy: IfNotPresent
 
 # -- Optional secrets used for pulling the istio-csr container image.


### PR DESCRIPTION
Similarly to other projects, we want to use a Helm template to generate the OCI image URL.
See https://github.com/cert-manager/cert-manager/issues/6329 for more info.