### PR TITLE
add ability to provide additional DNS names to istiod certificate

### DIFF
--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -550,6 +550,23 @@ https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf
 </tr>
 <tr>
 
+<td>app.tls.istiodAdditionalDNSNames</td>
+<td>
+
+Provide additional DNS names to request on the istiod certificate. Useful if istiod should be accessible via multiple DNS names and/or outside of the cluster.
+
+</td>
+<td>array</td>
+<td>
+
+```yaml
+[]
+```
+
+</td>
+</tr>
+<tr>
+
 <td>app.tls.istiodCertificateDuration</td>
 <td>
 

--- a/deploy/charts/istio-csr/templates/certificate.yaml
+++ b/deploy/charts/istio-csr/templates/certificate.yaml
@@ -29,6 +29,11 @@ spec:
   {{- else }}
   - istiod.{{ .Values.app.istio.namespace }}.svc
   {{- end }}
+  {{- if .Values.app.tls.istiodAdditionalDNSNames }}
+  {{- range .Values.app.tls.istiodAdditionalDNSNames }}
+  - {{ . }}
+  {{- end }}
+  {{- end }}
   uris:
   - spiffe://{{.Values.app.tls.trustDomain}}/ns/{{ .Values.app.istio.namespace }}/sa/istiod-service-account
   secretName: istiod-tls

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -106,6 +106,9 @@ app:
     # Based on NIST 800-204A recommendations (SM-DR13).
     # https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf
     certificateDuration: 1h
+    # Provide additional DNS names to request on the istiod certificate. Useful if istiod 
+    # should be accessible via multiple DNS names and/or outside of the cluster.
+    istiodAdditionalDNSNames: []
     # Requested duration of istio's Certificate. Will be automatically
     # renewed.
     # Based on NIST 800-204A recommendations (SM-DR13).

--- a/test/carotation/values/istio-csr-2.yaml
+++ b/test/carotation/values/istio-csr-2.yaml
@@ -21,6 +21,8 @@ app:
     trustDomain: foo.bar
     rootCAFile: /var/run/secrets/istio-csr/ca.pem
     certificateDuration: 20s
+    istiodAdditionalDNSNames:
+    - istiod.istio-system.svc.cluster.local
 
 volumes:
 - name: istio-root-certs


### PR DESCRIPTION
Add ability to provide additional istiod DNS certificates. Useful when istiod should be reachable from outside the Kubernetes cluster.

Signed-off-by: Edgaras <edgaras@apsega.lt>
