### PR TITLE
Fix values.yaml

### DIFF
--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -74,9 +74,10 @@ Service type to expose istio-csr gRPC service.
 > ```
 
 Service port to expose istio-csr gRPC service.
-#### **service.nodePort** ~ `unknown`
+#### **service.nodePort** ~ `number`
 
 Service nodePort to expose istio-csr gRPC service.
+
 
 #### **app.logLevel** ~ `number`
 > Default value:

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -74,6 +74,10 @@ Service type to expose istio-csr gRPC service.
 > ```
 
 Service port to expose istio-csr gRPC service.
+#### **service.nodePort** ~ `unknown`
+
+Service nodePort to expose istio-csr gRPC service.
+
 #### **app.logLevel** ~ `number`
 > Default value:
 > ```yaml
@@ -325,13 +329,10 @@ The namespace where the istio control-plane is running.
 > istio-system
 > ```
 #### **app.controller.configmapNamespaceSelector** ~ `string`
-> Default value:
-> ```yaml
-> null
-> ```
 
 If set, limit where istio-csr creates configmaps with root ca certificates. If unset, configmap created in ALL namespaces.  
 Example: maistra.io/member-of=istio-system
+
 
 #### **volumes** ~ `array`
 > Default value:

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -27,6 +27,7 @@ service:
   # Service port to expose istio-csr gRPC service.
   port: 443
   # Service nodePort to expose istio-csr gRPC service.
+  # +docs:type=number
   # +docs:property
   # nodePort:
 

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -26,6 +26,9 @@ service:
   type: ClusterIP
   # Service port to expose istio-csr gRPC service.
   port: 443
+  # Service nodePort to expose istio-csr gRPC service.
+  # +docs:property
+  # nodePort:
 
 app:
   # Verbosity of istio-csr logging.
@@ -160,7 +163,8 @@ app:
     # If set, limit where istio-csr creates configmaps with root ca certificates. If unset, configmap created in ALL namespaces.
     # Example: maistra.io/member-of=istio-system
     # +docs:type=string
-    configmapNamespaceSelector:
+    # +docs:property
+    # configmapNamespaceSelector:
 
 # Optional extra volumes. Useful for mounting custom root CAs
 #


### PR DESCRIPTION
- The nodePort option was not documented in the values.yaml file
- configmapNamespaceSelector is a string, but was set to null by default

Prepares the chart for https://github.com/cert-manager/istio-csr/pull/258