### PR TITLE
Helm: set linux nodeSelector by default

### DIFF
--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -424,8 +424,11 @@ tolerations:
 #### **nodeSelector** ~ `object`
 > Default value:
 > ```yaml
-> {}
+> kubernetes.io/os: linux
 > ```
+
+Kubernetes node selector: node labels for pod assignment.
+
 #### **commonLabels** ~ `object`
 > Default value:
 > ```yaml

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -508,7 +508,10 @@
       "type": "array"
     },
     "helm-values.nodeSelector": {
-      "default": {},
+      "default": {
+        "kubernetes.io/os": "linux"
+      },
+      "description": "Kubernetes node selector: node labels for pod assignment.",
       "type": "object"
     },
     "helm-values.replicaCount": {

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -229,7 +229,10 @@ affinity: {}
 #     effect: NoSchedule
 tolerations: []
 
-nodeSelector: {}
+# Kubernetes node selector: node labels for pod assignment.
+# +docs:property=nodeSelector
+nodeSelector:
+  kubernetes.io/os: linux
 
 # Labels to apply to all resources
 commonLabels: {}


### PR DESCRIPTION
Similar to cert-manager and csi-driver-spiffe, set the nodeSelector to kubernetes.io/os: linux by default.