### PR TITLE
Add ability to configure issuer at runtime

### DIFF
--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -101,6 +101,12 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("failed to create manager: %w", err)
 			}
 
+			if opts.CertManager.HasRuntimeConfiguration() {
+				if err := mgr.Add(cm.RuntimeConfigurationWatcher(ctx)); err != nil {
+					return fmt.Errorf("failed to add runtime configuration watcher as runnable: %w", err)
+				}
+			}
+
 			// Create a new TLS provider for the serving certificate and private key.
 			tls, err := tls.NewProvider(opts.Logr, cm, opts.TLS)
 			if err != nil {

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -229,6 +229,13 @@ func (o *Options) addCertManagerFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&o.CertManager.IssuerRef.Group,
 		"issuer-group", "g", "cert-manager.io",
 		"Group of the issuer to sign istio workload certificates.")
+
+	fs.StringVar(&o.CertManager.IssuanceConfigMapName, "runtime-issuance-config-map-name", "",
+		"Name of a ConfigMap to watch at runtime for issuer details. If such a ConfigMap is found, overrides issuer-name, issuer-kind and issuer-group")
+
+	fs.StringVar(&o.CertManager.IssuanceConfigMapNamespace, "runtime-issuance-config-map-namespace", "",
+		"Namespace for ConfigMap to be watched at runtime for issuer details")
+
 }
 
 func (o *Options) addAdditionalAnnotationsFlags(fs *pflag.FlagSet) {

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -139,6 +139,15 @@ The timeout on each metric probe request.
 > ```
 
 Additional labels to give the ServiceMonitor resource.
+#### **app.runtimeIssuanceConfigMap** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
+
+Name of a ConfigMap in the installation namespace to watch, providing runtime configuration of an issuer to use.  
+  
+The "issuer-name", "issuer-kind" and "issuer-group" keys must be present in the ConfigMap for it to be used.
 #### **app.readinessProbe.port** ~ `number`
 > Default value:
 > ```yaml

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -89,6 +89,9 @@ spec:
           {{- if .Values.app.controller.configmapNamespaceSelector }}
           - "--configmap-namespace-selector={{ .Values.app.controller.configmapNamespaceSelector }}"
           {{- end }}
+
+          - "--runtime-issuance-config-map-name={{.Values.app.runtimeIssuanceConfigMap}}"
+          - "--runtime-issuance-config-map-namespace={{.Release.Namespace}}"
         {{- if .Values.volumeMounts }}
         volumeMounts:
 {{ toYaml .Values.volumeMounts | indent 10 }}

--- a/deploy/charts/istio-csr/templates/role.yaml
+++ b/deploy/charts/istio-csr/templates/role.yaml
@@ -20,3 +20,10 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["create"]
+{{- if .Values.app.runtimeIssuanceConfigMap }}
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
+  resourceNames: ["{{.Values.app.runtimeIssuanceConfigMap}}"]
+{{- end }}
+

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -71,6 +71,9 @@
         "readinessProbe": {
           "$ref": "#/$defs/helm-values.app.readinessProbe"
         },
+        "runtimeIssuanceConfigMap": {
+          "$ref": "#/$defs/helm-values.app.runtimeIssuanceConfigMap"
+        },
         "server": {
           "$ref": "#/$defs/helm-values.app.server"
         },
@@ -305,6 +308,11 @@
       "default": 6060,
       "description": "Container port to expose istio-csr HTTP readiness probe on default network interface.",
       "type": "number"
+    },
+    "helm-values.app.runtimeIssuanceConfigMap": {
+      "default": "",
+      "description": "Name of a ConfigMap in the installation namespace to watch, providing runtime configuration of an issuer to use.\n\nThe \"issuer-name\", \"issuer-kind\" and \"issuer-group\" keys must be present in the ConfigMap for it to be used.",
+      "type": "string"
     },
     "helm-values.app.server": {
       "additionalProperties": false,

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -57,7 +57,7 @@ app:
         # Create Prometheus ServiceMonitor resource for approver-policy.
         enabled: false
         # The value for the "prometheus" label on the ServiceMonitor. This allows
-        # for multiple Prometheus instances selecting difference ServiceMonitors 
+        # for multiple Prometheus instances selecting difference ServiceMonitors
         # using label selectors.
         prometheusInstance: default
         # The interval that the Prometheus will scrape for metrics.
@@ -66,6 +66,13 @@ app:
         scrapeTimeout: 5s
         # Additional labels to give the ServiceMonitor resource.
         labels: {}
+
+  # Name of a ConfigMap in the installation namespace to watch, providing
+  # runtime configuration of an issuer to use.
+  #
+  # The "issuer-name", "issuer-kind" and "issuer-group" keys must be present in
+  # the ConfigMap for it to be used.
+  runtimeIssuanceConfigMap: ""
 
   readinessProbe:
     # Container port to expose istio-csr HTTP readiness probe on default network interface.
@@ -118,7 +125,7 @@ app:
     # Based on NIST 800-204A recommendations (SM-DR13).
     # https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf
     certificateDuration: 1h
-    # Provide additional DNS names to request on the istiod certificate. Useful if istiod 
+    # Provide additional DNS names to request on the istiod certificate. Useful if istiod
     # should be accessible via multiple DNS names and/or outside of the cluster.
     istiodAdditionalDNSNames: []
     # Requested duration of istio's Certificate. Will be automatically

--- a/make/config/istio-csr-values.yaml
+++ b/make/config/istio-csr-values.yaml
@@ -1,4 +1,4 @@
-replicaCount: 3
+replicaCount: 2
 
 service:
   port: 443

--- a/pkg/certmanager/certmanager.go
+++ b/pkg/certmanager/certmanager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
@@ -28,10 +29,13 @@ import (
 	cmversioned "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1"
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 const (
@@ -49,8 +53,18 @@ type Options struct {
 	// IssuerRef is used as the issuerRef on created CertificateRequests.
 	IssuerRef cmmeta.ObjectReference
 
+	// IssuanceConfigMapName is the name of a ConfigMap to watch for configuration options. The ConfigMap is expected to be in the same namespace as the csi-driver-spiffe pod.
+	IssuanceConfigMapName string
+
+	// IssuanceConfigMapNamespace is the namespace where the runtime configuration ConfigMap is located
+	IssuanceConfigMapNamespace string
+
 	// AdditionalAnnotations are any additional annotations to include on created CertificateRequests.
 	AdditionalAnnotations map[string]string
+}
+
+func (o Options) HasRuntimeConfiguration() bool {
+	return o.IssuanceConfigMapName != "" && o.IssuanceConfigMapNamespace != ""
 }
 
 type Signer interface {
@@ -68,7 +82,22 @@ type manager struct {
 	opts Options
 	log  logr.Logger
 
-	client cmclient.CertificateRequestInterface
+	// kubernetesClient is used to watch ConfigMaps for issuance configuration
+	kubernetesClient client.WithWatch
+
+	certManagerClient cmclient.CertificateRequestInterface
+
+	// activeIssuerRef controls the issuerRef actually used when creating
+	// CertificateRequest objects. Can be empty, which will cause issuance to
+	// fail until runtime configuration is applied.
+	activeIssuerRef *cmmeta.ObjectReference
+
+	activeIssuerRefMutex sync.RWMutex
+
+	// originalIssuerRef is the issuerRef passed at startup. This will be used
+	// if no runtime configuration (ConfigMap configuration) is found, or if the
+	// ConfigMap for runtime configuration is deleted.
+	originalIssuerRef *cmmeta.ObjectReference
 }
 
 // Bundle represents the `status.Certificate` and `status.CA` that is
@@ -79,20 +108,53 @@ type Bundle struct {
 }
 
 func New(log logr.Logger, restConfig *rest.Config, opts Options) (*manager, error) {
-	client, err := cmversioned.NewForConfig(restConfig)
+	k8sClient, err := client.NewWithWatch(restConfig, client.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to build kubernetes watcher client: %w", err)
+	}
+
+	cmClient, err := cmversioned.NewForConfig(restConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build cert-manager client: %s", err)
 	}
 
+	originalIssuerRef, err := handleOriginalIssuerRef(opts.IssuerRef)
+	if err != nil && err != errNoOriginalIssuer {
+		return nil, fmt.Errorf("invalid issuerRef passed at startup: %s", err)
+	}
+
+	activeIssuerRef := originalIssuerRef
+
+	if err == errNoOriginalIssuer {
+		if !opts.HasRuntimeConfiguration() {
+			return nil, fmt.Errorf("runtime configuration parameters for name and namespace are required if no issuerRef is provided on startup")
+		}
+
+		activeIssuerRef = nil
+	}
+
 	return &manager{
-		log:    log.WithName("cert-manager"),
-		client: client.CertmanagerV1().CertificateRequests(opts.Namespace),
-		opts:   opts,
+		log: log.WithName("cert-manager"),
+
+		kubernetesClient:  k8sClient,
+		certManagerClient: cmClient.CertmanagerV1().CertificateRequests(opts.Namespace),
+		opts:              opts,
+
+		activeIssuerRef: activeIssuerRef,
+
+		originalIssuerRef: originalIssuerRef,
 	}, nil
 }
 
 // Sign will sign a request against the manager's configured client.
 func (m *manager) Sign(ctx context.Context, identities string, csrPEM []byte, duration time.Duration, usages []cmapi.KeyUsage) (Bundle, error) {
+	m.activeIssuerRefMutex.RLock()
+	defer m.activeIssuerRefMutex.RUnlock()
+
+	if m.activeIssuerRef == nil {
+		return Bundle{}, fmt.Errorf("no active issuerRef is configured for istio-csr")
+	}
+
 	cr := &cmapi.CertificateRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "istio-csr-",
@@ -107,7 +169,7 @@ func (m *manager) Sign(ctx context.Context, identities string, csrPEM []byte, du
 			IsCA:      false,
 			Request:   csrPEM,
 			Usages:    usages,
-			IssuerRef: m.opts.IssuerRef,
+			IssuerRef: *m.activeIssuerRef,
 		},
 	}
 
@@ -115,7 +177,7 @@ func (m *manager) Sign(ctx context.Context, identities string, csrPEM []byte, du
 		cr.ObjectMeta.Annotations[k] = v
 	}
 	// Create CertificateRequest and wait for it to be successfully signed.
-	cr, err := m.client.Create(ctx, cr, metav1.CreateOptions{})
+	cr, err := m.certManagerClient.Create(ctx, cr, metav1.CreateOptions{})
 	if err != nil {
 		return Bundle{}, fmt.Errorf("failed to create CertificateRequest: %w", err)
 	}
@@ -134,7 +196,7 @@ func (m *manager) Sign(ctx context.Context, identities string, csrPEM []byte, du
 				// gRPC context closing.
 				cleanupCtx := context.Background()
 
-				if err := m.client.Delete(cleanupCtx, cr.Name, metav1.DeleteOptions{}); err != nil {
+				if err := m.certManagerClient.Delete(cleanupCtx, cr.Name, metav1.DeleteOptions{}); err != nil {
 					log.Error(err, "failed to delete CertificateRequest")
 					return
 				}
@@ -160,7 +222,7 @@ func (m *manager) Sign(ctx context.Context, identities string, csrPEM []byte, du
 // the terminal state is either Denied or Failed, then this will also return an
 // error.
 func (m *manager) waitForCertificateRequest(ctx context.Context, log logr.Logger, cr *cmapi.CertificateRequest) (*cmapi.CertificateRequest, error) {
-	watcher, err := m.client.Watch(ctx, metav1.ListOptions{
+	watcher, err := m.certManagerClient.Watch(ctx, metav1.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(metav1.ObjectNameField, cr.Name).String(),
 	})
 	if err != nil {
@@ -169,7 +231,7 @@ func (m *manager) waitForCertificateRequest(ctx context.Context, log logr.Logger
 	defer watcher.Stop()
 
 	// Get the request in-case it has already reached a terminal state.
-	cr, err = m.client.Get(ctx, cr.Name, metav1.GetOptions{})
+	cr, err = m.certManagerClient.Get(ctx, cr.Name, metav1.GetOptions{})
 	if err != nil {
 		return cr, fmt.Errorf("failed to get CertificateRequest: %w", err)
 	}
@@ -210,4 +272,188 @@ func (m *manager) waitForCertificateRequest(ctx context.Context, log logr.Logger
 			break
 		}
 	}
+}
+
+const (
+	issuerNameKey  = "issuer-name"
+	issuerKindKey  = "issuer-kind"
+	issuerGroupKey = "issuer-group"
+)
+
+func (m *manager) handleRuntimeConfigIssuerChange(logger logr.Logger, event watch.Event) error {
+	m.activeIssuerRefMutex.Lock()
+	defer m.activeIssuerRefMutex.Unlock()
+
+	cm, ok := event.Object.(*corev1.ConfigMap)
+	if !ok {
+		return fmt.Errorf("got unexpected type for runtime configuration source; this is likely a programming error")
+	}
+
+	issuerRef := &cmmeta.ObjectReference{}
+
+	var dataErrs []error
+	var exists bool
+
+	issuerRef.Name, exists = cm.Data[issuerNameKey]
+	if !exists || len(issuerRef.Name) == 0 {
+		dataErrs = append(dataErrs, fmt.Errorf("missing key/value in ConfigMap data: %s", issuerNameKey))
+	}
+
+	issuerRef.Kind, exists = cm.Data[issuerKindKey]
+	if !exists || len(issuerRef.Kind) == 0 {
+		dataErrs = append(dataErrs, fmt.Errorf("missing key/value in ConfigMap data: %s", issuerKindKey))
+	}
+
+	issuerRef.Group, exists = cm.Data[issuerGroupKey]
+	if !exists || len(issuerRef.Group) == 0 {
+		dataErrs = append(dataErrs, fmt.Errorf("missing key/value in ConfigMap data; %s", issuerGroupKey))
+	}
+
+	if len(dataErrs) > 0 {
+		return errors.Join(dataErrs...)
+	}
+
+	// we now have a full issuerRef
+	// TODO: check if the issuer exists by querying for the CRD?
+
+	m.activeIssuerRef = issuerRef
+
+	logger.Info("Changed active issuerRef in response to runtime configuration ConfigMap", "issuer-name", m.activeIssuerRef.Name, "issuer-kind", m.activeIssuerRef.Kind, "issuer-group", m.activeIssuerRef.Group)
+
+	return nil
+}
+
+func (m *manager) handleRuntimeConfigIssuerDeletion(logger logr.Logger) {
+	m.activeIssuerRefMutex.Lock()
+	defer m.activeIssuerRefMutex.Unlock()
+
+	if m.originalIssuerRef == nil {
+		logger.Info("Runtime issuance configuration was deleted and no issuerRef was configured at install time; issuance will fail until runtime configuration is reinstated")
+		m.activeIssuerRef = nil
+		return
+	}
+
+	logger.Info("Runtime issuance configuration was deleted; issuance will revert to original issuerRef configured at install time")
+
+	m.activeIssuerRef = m.originalIssuerRef
+}
+
+// RuntimeConfigurationWatcher is a wrapper around ctrlmgr.Runnable for watching runtime config
+type RuntimeConfigurationWatcher struct {
+	m *manager
+}
+
+// NeedLeaderElection always returns false, ensuring that the runtime configuration
+// watcher is always invoked even if we don't hold the lock. This ensures we use the
+// correct CA for renewing the serving cert, and that we're using the most up-to-date
+// issuerRef for when we do acquire the lock.
+func (rcw *RuntimeConfigurationWatcher) NeedLeaderElection() bool {
+	return false
+}
+
+func (rcw *RuntimeConfigurationWatcher) Start(ctx context.Context) error {
+	logger := rcw.m.log.WithName("runtime-config-watcher").WithValues("config-map-name", rcw.m.opts.IssuanceConfigMapName, "config-map-namespace", rcw.m.opts.IssuanceConfigMapNamespace)
+
+LOOP:
+	for {
+		logger.Info("Starting / restarting watcher for runtime configuration")
+		cmList := &corev1.ConfigMapList{}
+
+		// First create a watcher. This is in a labelled loop in case the watcher dies for some reason
+		// while we're running - in that case, we don't want to give up entirely on watching for runtime config
+		// but instead we want to recreate the watcher.
+
+		watcher, err := rcw.m.kubernetesClient.Watch(ctx, cmList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector("metadata.name", rcw.m.opts.IssuanceConfigMapName),
+			Namespace:     rcw.m.opts.IssuanceConfigMapNamespace,
+		})
+
+		if err != nil {
+			logger.Error(err, "Failed to create ConfigMap watcher; will retry in 5s")
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		for {
+			// Now loop indefinitely until the main context cancels or we get an event to process.
+			// If the main context cancels, we break out of the outer loop and this function returns.
+			// If we get an event, we first check whether the channel closed. If so, we recreate the watcher by continuing
+			// the outer loop.
+			select {
+			case <-ctx.Done():
+				logger.Info("Received context cancellation, shutting down runtime configuration watcher")
+				watcher.Stop()
+				break LOOP
+
+			case event, open := <-watcher.ResultChan():
+				if !open {
+					logger.Info("Received closed channel from ConfigMap watcher, will recreate")
+					watcher.Stop()
+					continue LOOP
+				}
+
+				switch event.Type {
+				case watch.Deleted:
+					rcw.m.handleRuntimeConfigIssuerDeletion(logger)
+
+				case watch.Added:
+					err := rcw.m.handleRuntimeConfigIssuerChange(logger, event)
+					if err != nil {
+						logger.Error(err, "Failed to handle new runtime configuration for issuerRef")
+					}
+
+				case watch.Modified:
+					err := rcw.m.handleRuntimeConfigIssuerChange(logger, event)
+					if err != nil {
+						logger.Error(err, "Failed to handle runtime configuration issuerRef change")
+					}
+
+				case watch.Bookmark:
+					// Ignore
+
+				case watch.Error:
+					err, ok := event.Object.(error)
+					if !ok {
+						logger.Error(nil, "Got an error event when watching runtime configuration but unable to determine further information")
+					} else {
+						logger.Error(err, "Got an error event when watching runtime configuration")
+					}
+
+				default:
+					logger.Info("Got unknown event for runtime configuration ConfigMap; ignoring", "event-type", string(event.Type))
+				}
+			}
+		}
+	}
+
+	logger.Info("Stopped runtime configuration watcher")
+	return nil
+}
+
+func (m *manager) RuntimeConfigurationWatcher(ctx context.Context) ctrlmgr.Runnable {
+	return &RuntimeConfigurationWatcher{
+		m: m,
+	}
+}
+
+var errNoOriginalIssuer = fmt.Errorf("no original issuer was provided")
+
+func handleOriginalIssuerRef(in cmmeta.ObjectReference) (*cmmeta.ObjectReference, error) {
+	if in.Name == "" && in.Kind == "" && in.Group == "" {
+		return nil, errNoOriginalIssuer
+	}
+
+	if in.Name == "" {
+		return nil, fmt.Errorf("issuerRef.Name is a required field if any field is set for issuerRef")
+	}
+
+	if in.Kind == "" {
+		return nil, fmt.Errorf("issuerRef.Kind is a required field if any field is set for issuerRef")
+	}
+
+	if in.Group == "" {
+		return nil, fmt.Errorf("issuerRef.Group is a required field if any field is set for issuerRef")
+	}
+
+	return &in, nil
 }

--- a/test/e2e/framework/config/config.go
+++ b/test/e2e/framework/config/config.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 type Config struct {
@@ -29,6 +28,11 @@ type Config struct {
 	KubectlPath    string
 
 	IssuerRef cmmeta.ObjectReference
+
+	IssuanceConfigMapName      string
+	IssuanceConfigMapNamespace string
+
+	IstioctlPath string
 }
 
 var (
@@ -49,6 +53,11 @@ func (c *Config) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.IssuerRef.Group, "issuer-group ", "cert-manager.io", "issuer Group to use for e2e test")
 	fs.StringVar(&c.KubeConfigPath, "kubeconfig-path", "", "path to Kubeconfig")
 	fs.StringVar(&c.KubectlPath, "kubectl-path", "", "path to Kubectl binary")
+
+	fs.StringVar(&c.IssuanceConfigMapName, "runtime-issuance-config-map-name", "runtime-config-map", "Name of runtime issuance ConfigMap")
+	fs.StringVar(&c.IssuanceConfigMapNamespace, "runtime-issuance-config-map-namespace", "cert-manager", "Namespace for runtime issuance ConfigMap")
+
+	fs.StringVar(&c.IstioctlPath, "istioctl-path", "", "path to istioctl binary")
 }
 
 func (c *Config) Validate() error {
@@ -62,5 +71,9 @@ func (c *Config) Validate() error {
 		errs = append(errs, errors.New("--kubectl-path not set"))
 	}
 
-	return utilerrors.NewAggregate(errs)
+	if c.IstioctlPath == "" {
+		errs = append(errs, errors.New("--istioctl-path not set"))
+	}
+
+	return errors.Join(errs...)
 }

--- a/test/e2e/runtimeconfig-manifests/configmap/configmap.yaml
+++ b/test/e2e/runtimeconfig-manifests/configmap/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: runtime-config-map
+  namespace: cert-manager
+data:
+  issuer-name: runtimeconfig-ca-issuer
+  issuer-kind: Issuer
+  issuer-group: cert-manager.io

--- a/test/e2e/runtimeconfig-manifests/issuers/issuer.yaml
+++ b/test/e2e/runtimeconfig-manifests/issuers/issuer.yaml
@@ -1,0 +1,34 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: runtimeconfig-ca
+  namespace: istio-system
+spec:
+  isCA: true
+  commonName: runtimeconfig-ca
+  secretName: runtimeconfig-ca-secret
+  duration: 2160h # 90d
+  subject:
+    organizations:
+    - cluster.local
+    - cert-manager
+    organizationalUnits:
+    - runtimeconfig
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: istio-ca
+    kind: Issuer
+    group: cert-manager.io
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: runtimeconfig-ca-issuer
+  namespace: istio-system
+spec:
+  ca:
+    secretName: runtimeconfig-ca-secret

--- a/test/e2e/suite/doc.go
+++ b/test/e2e/suite/doc.go
@@ -20,4 +20,5 @@ import (
 	_ "github.com/cert-manager/istio-csr/test/e2e/suite/mtls"
 	_ "github.com/cert-manager/istio-csr/test/e2e/suite/namespace"
 	_ "github.com/cert-manager/istio-csr/test/e2e/suite/request"
+	_ "github.com/cert-manager/istio-csr/test/e2e/suite/runtimeconfiguration"
 )

--- a/test/e2e/suite/mtls/mtls.go
+++ b/test/e2e/suite/mtls/mtls.go
@@ -89,8 +89,21 @@ var _ = framework.CasesDescribe("mTLS correctness", func() {
 		}
 
 		for _, ns := range namespaces {
-			By(fmt.Sprintf("waiting for pods in %q namespace to become ready", ns.name))
-			err := f.Helper().WaitForPodsReady(ctx, ns.name, time.Minute*10)
+			By(fmt.Sprintf("waiting for sleep pods in %q namespace to become ready", ns.name))
+
+			err := f.Helper().WaitForLabelledPodsReady(ctx, ns.name, "app=sleep", time.Minute*10)
+			if err != nil {
+				// #nosec G204
+				cmd := exec.Command(f.Config().KubectlPath, "describe", "-n", ns.name, "pods")
+				cmd.Stdout = GinkgoWriter
+				cmd.Stderr = GinkgoWriter
+				Expect(cmd.Run()).NotTo(HaveOccurred())
+
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			By(fmt.Sprintf("waiting for httpbin pods in %q namespace to become ready", ns.name))
+			err = f.Helper().WaitForLabelledPodsReady(ctx, ns.name, "app=httpbin", time.Minute*10)
 			if err != nil {
 				// #nosec G204
 				cmd := exec.Command(f.Config().KubectlPath, "describe", "-n", ns.name, "pods")

--- a/test/e2e/suite/runtimeconfiguration/runtimeconfiguration.go
+++ b/test/e2e/suite/runtimeconfiguration/runtimeconfiguration.go
@@ -1,0 +1,270 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mtls
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"time"
+
+	cmutil "github.com/cert-manager/cert-manager/pkg/util/pki"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cert-manager/istio-csr/test/e2e/framework"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = framework.CasesDescribe("runtime configuration", func() {
+	f := framework.NewDefaultFramework("runtime-configuration")
+
+	var (
+		namespaceName = "runtimeconfig-ns"
+
+		ctx = context.Background()
+	)
+
+	JustBeforeEach(func() {
+		_, err := f.KubeClientSet.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespaceName,
+				Labels: map[string]string{
+					"istio-injection": "enabled",
+				},
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating runtime configuration issuer")
+		err = kubectl(f, "apply", "-f", "./runtimeconfig-manifests/issuers/.")
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating deployments in runtimeconfig namespace")
+		err = kubectl(f, "apply", "-n", namespaceName, "-f", "./manifests/sleep.yaml")
+		Expect(err).NotTo(HaveOccurred())
+
+		By("waiting for sleep pods in runtimeconfig namespace to become ready")
+		err = f.Helper().WaitForLabelledPodsReady(ctx, namespaceName, "app=sleep", time.Minute*10)
+		if err != nil {
+			err := kubectl(f, "describe", "-n", namespaceName, "pods")
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+
+	JustAfterEach(func() {
+		By("deleting runtimeconfig namespace with deployments")
+
+		err := f.KubeClientSet.CoreV1().Namespaces().Delete(ctx, namespaceName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("it should use the runtime configured issuer", func() {
+		By("creating runtime configuration configmap")
+		err := kubectl(f, "apply", "-f", "./runtimeconfig-manifests/configmap/.")
+		Expect(err).NotTo(HaveOccurred())
+
+		defer func() {
+			err := cleanupRuntimeConfigResources(f)
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		{
+			By("checking that already-created pods use the old issuer")
+			pods, err := f.KubeClientSet.CoreV1().Pods(namespaceName).List(ctx, metav1.ListOptions{
+				LabelSelector: "app=sleep",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			if len(pods.Items) != 1 {
+				Expect(fmt.Errorf("expected single sleep pod in ns %q, got=%d", namespaceName, len(pods.Items))).NotTo(HaveOccurred())
+			}
+
+			certsBefore, err := istioctlGetCert(f, pods.Items[0].Name, namespaceName)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(certsBefore).To(HaveLen(2), "expected exactly 2 certificates for the running sleep pod chain")
+
+			Expect(certsBefore[0].Issuer.OrganizationalUnit).To(BeEmpty(), "expected no OUs in running sleep pod's issuer")
+
+			By("Deleting sleep pod to trigger re-issuance")
+			err = kubectl(f, "delete", "-n", namespaceName, "pods", pods.Items[0].Name)
+			Expect(err).NotTo(HaveOccurred())
+
+		}
+
+		err = f.Helper().WaitForLabelledPodsReady(ctx, namespaceName, "app=sleep", time.Minute*10)
+		if err != nil {
+			err := kubectl(f, "describe", "-n", namespaceName, "pods")
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		{
+			By("checking that the new sleep pod uses the runtime-configured issuer")
+			pods, err := f.KubeClientSet.CoreV1().Pods(namespaceName).List(ctx, metav1.ListOptions{
+				LabelSelector: "app=sleep",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			if len(pods.Items) != 1 {
+				Expect(fmt.Errorf("expected single sleep pod in ns %q, got=%d", namespaceName, len(pods.Items))).NotTo(HaveOccurred())
+			}
+
+			certsAfter, err := istioctlGetCert(f, pods.Items[0].Name, namespaceName)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(certsAfter).To(HaveLen(3), "expected exactly 3 certificates for the running sleep pod chain")
+
+			Expect(certsAfter[0].Issuer.OrganizationalUnit).To(HaveLen(1), "expected one OU in running sleep pod's issuer")
+			Expect(certsAfter[0].Issuer.OrganizationalUnit[0]).To(Equal("runtimeconfig"), "expected 'runtimeconfig' OU for issuer of workload identity")
+		}
+	})
+})
+
+// diveMap "dives" into a map, extracting another map from the given key and performing error checks
+func diveMap(m map[string]any, key string) (map[string]any, error) {
+	rawObject, exists := m[key]
+	if !exists {
+		return nil, fmt.Errorf("key %q not found in map", key)
+	}
+
+	innerMap, isMap := rawObject.(map[string]any)
+	if !isMap {
+		return nil, fmt.Errorf("key %q in map was not an object with string keys", key)
+	}
+
+	return innerMap, nil
+}
+
+func kubectl(f *framework.Framework, args ...string) error {
+	stdout, err := kubectlWithOutput(f, args...)
+
+	GinkgoWriter.Println(stdout)
+
+	return err
+}
+
+func kubectlWithOutput(f *framework.Framework, args ...string) (string, error) {
+	buf := &bytes.Buffer{}
+
+	// #nosec G204
+	cmd := exec.Command(f.Config().KubectlPath, args...)
+
+	cmd.Stdout = buf
+	cmd.Stderr = GinkgoWriter
+
+	err := cmd.Run()
+
+	return buf.String(), err
+}
+
+func cleanupRuntimeConfigResources(f *framework.Framework) error {
+	var cleanupErrs []error
+
+	err := kubectl(f, "delete", "-f", "./runtimeconfig-manifests/configmap/.")
+	if err != nil {
+		cleanupErrs = append(cleanupErrs, err)
+	}
+
+	err = kubectl(f, "delete", "-f", "./runtimeconfig-manifests/issuers/.")
+	if err != nil {
+		cleanupErrs = append(cleanupErrs, err)
+	}
+
+	return errors.Join(cleanupErrs...)
+}
+
+type IstioctlSecret struct {
+	Name        string         `json:"name"`
+	LastUpdated string         `json:"lastUpdated"`
+	Secret      map[string]any `json:"secret"`
+}
+
+type IstioctlJSONWrapper struct {
+	DynamicActiveSecrets []IstioctlSecret `json:"dynamicActiveSecrets"`
+}
+
+func istioctlGetCert(f *framework.Framework, podName string, namespaceName string) ([]*x509.Certificate, error) {
+	buf := &bytes.Buffer{}
+
+	// #nosec G204
+	cmd := exec.Command(f.Config().IstioctlPath, "proxy-config", "secrets", "-n", namespaceName, podName, "-ojson")
+
+	cmd.Stdout = buf
+	cmd.Stderr = GinkgoWriter
+
+	err := cmd.Run()
+	if err != nil {
+		GinkgoWriter.Println(buf.String())
+		return nil, err
+	}
+
+	jsonOutput := buf.Bytes()
+
+	var wrapper IstioctlJSONWrapper
+
+	err = json.Unmarshal(jsonOutput, &wrapper)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(wrapper.DynamicActiveSecrets) == 0 {
+		return nil, fmt.Errorf("fatal: got no secrets from istioctl")
+	}
+
+	for _, secret := range wrapper.DynamicActiveSecrets {
+		if secret.Name != "default" {
+			continue
+		}
+
+		tlsCertificateMap, err := diveMap(secret.Secret, "tlsCertificate")
+		if err != nil {
+			return nil, err
+		}
+
+		certificateChainMap, err := diveMap(tlsCertificateMap, "certificateChain")
+		if err != nil {
+			return nil, err
+		}
+
+		base64Raw, ok := certificateChainMap["inlineBytes"]
+		if !ok {
+			return nil, fmt.Errorf("failed to find inlineBytes key in certificateChain part of secret")
+		}
+
+		base64String, ok := base64Raw.(string)
+		if !ok {
+			return nil, fmt.Errorf("failed to convert inlineBytes to a string")
+		}
+
+		chainBytes, err := base64.StdEncoding.DecodeString(base64String)
+		if err != nil {
+			return nil, err
+		}
+
+		return cmutil.DecodeX509CertificateSetBytes(chainBytes)
+	}
+
+	return nil, fmt.Errorf("couldn't find cert secret for %s/%s", namespaceName, podName)
+}


### PR DESCRIPTION
This commit allows users to specify the name of a ConfigMap which should be watched for issuer configuration. Importantly, this allows for istio-csr to be installed at the same time as cert-manager without needing an issuer to already exist

The helm chart assumes that the ConfigMap is in the same namespace as the istio-csr Deployment.

This is very similar to https://github.com/cert-manager/csi-driver-spiffe/pull/141 which implemented similar functionality for csi-driver-spiffe.

While this is similar to csi-driver-spiffe, a key difference is that the runtime configuration configmap watcher in this PR is a controller-runtime Runnable.