### PR TITLE
Add updated versions of istio config to enable tests

### DIFF
--- a/make/config/istio/istio-config-1.19.9.yaml
+++ b/make/config/istio/istio-config-1.19.9.yaml
@@ -1,0 +1,20 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-system
+spec:
+  profile: "minimal"
+  meshConfig:
+    # Change the following line to configure the trust domain of the Istio cluster.
+    trustDomain: foo.bar
+  values:
+    global:
+      # Change certificate provider to cert-manager istio agent for istio agent
+      caAddress: cert-manager-istio-csr.cert-manager.svc:443
+  components:
+    pilot:
+      k8s:
+        env:
+          # Disable istiod CA Sever functionality
+        - name: ENABLE_CA_SERVER
+          value: "false"

--- a/make/config/istio/istio-config-1.20.8.yaml
+++ b/make/config/istio/istio-config-1.20.8.yaml
@@ -1,0 +1,20 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-system
+spec:
+  profile: "minimal"
+  meshConfig:
+    # Change the following line to configure the trust domain of the Istio cluster.
+    trustDomain: foo.bar
+  values:
+    global:
+      # Change certificate provider to cert-manager istio agent for istio agent
+      caAddress: cert-manager-istio-csr.cert-manager.svc:443
+  components:
+    pilot:
+      k8s:
+        env:
+          # Disable istiod CA Sever functionality
+        - name: ENABLE_CA_SERVER
+          value: "false"

--- a/make/config/istio/istio-config-1.21.4.yaml
+++ b/make/config/istio/istio-config-1.21.4.yaml
@@ -1,0 +1,20 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-system
+spec:
+  profile: "minimal"
+  meshConfig:
+    # Change the following line to configure the trust domain of the Istio cluster.
+    trustDomain: foo.bar
+  values:
+    global:
+      # Change certificate provider to cert-manager istio agent for istio agent
+      caAddress: cert-manager-istio-csr.cert-manager.svc:443
+  components:
+    pilot:
+      k8s:
+        env:
+          # Disable istiod CA Sever functionality
+        - name: ENABLE_CA_SERVER
+          value: "false"

--- a/make/config/istio/istio-config-1.22.2.yaml
+++ b/make/config/istio/istio-config-1.22.2.yaml
@@ -1,0 +1,20 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-system
+spec:
+  profile: "minimal"
+  meshConfig:
+    # Change the following line to configure the trust domain of the Istio cluster.
+    trustDomain: foo.bar
+  values:
+    global:
+      # Change certificate provider to cert-manager istio agent for istio agent
+      caAddress: cert-manager-istio-csr.cert-manager.svc:443
+  components:
+    pilot:
+      k8s:
+        env:
+          # Disable istiod CA Sever functionality
+        - name: ENABLE_CA_SERVER
+          value: "false"


### PR DESCRIPTION
This will allow us to test the latest patch release of existing versions and add support for testing 1.21.x and 1.22.x

I tested all of these configs locally and the e2e tests passed for all.