### PR TITLE
Increase timeout for namespace e2e test polling

### DIFF
--- a/make/test-e2e.mk
+++ b/make/test-e2e.mk
@@ -73,6 +73,15 @@ test-e2e-deps: e2e-create-cert-manager-istio-resources
 test-e2e-deps: install
 test-e2e-deps: e2e-setup-istio
 
+CI ?=
+EXTRA_GINKGO_FLAGS :=
+
+# In Prow, the CI environment variable is set to "true"
+# See https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+ifeq ($(CI),true)
+EXTRA_GINKGO_FLAGS += --no-color
+endif
+
 .PHONY: test-e2e
 ## e2e end-to-end tests
 ## @category Testing
@@ -81,6 +90,7 @@ test-e2e: test-e2e-deps | kind-cluster $(NEEDS_GINKGO) $(NEEDS_KUBECTL)
 		--output-dir=$(ARTIFACTS) \
 		--focus="$(E2E_FOCUS)" \
 		--junit-report=junit-go-e2e.xml \
+		$(EXTRA_GINKGO_FLAGS) \
 		./test/e2e/ \
 		-ldflags $(go_manager_ldflags) \
 		-- \

--- a/test/e2e/suite/namespace/namespace.go
+++ b/test/e2e/suite/namespace/namespace.go
@@ -85,7 +85,11 @@ var _ = framework.CasesDescribe("CA Root Controller", func() {
 	It("all namespaces should have valid configs in", func() {
 		By("ensure all existing namespaces have the correct root CA")
 
-		err := wait.PollUntilContextTimeout(ctx, time.Second, time.Second*30, true, func(ctx context.Context) (bool, error) {
+		pollInterval := 1 * time.Second
+		pollTimeout := 30 * time.Second
+		pollImmediate := true
+
+		err := wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, pollImmediate, func(ctx context.Context) (bool, error) {
 			nss, err := f.KubeClientSet.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 			if err != nil {
 				return false, err

--- a/test/e2e/suite/namespace/namespace.go
+++ b/test/e2e/suite/namespace/namespace.go
@@ -86,7 +86,7 @@ var _ = framework.CasesDescribe("CA Root Controller", func() {
 		By("ensure all existing namespaces have the correct root CA")
 
 		pollInterval := 1 * time.Second
-		pollTimeout := 30 * time.Second
+		pollTimeout := 2 * time.Minute
 		pollImmediate := true
 
 		err := wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, pollImmediate, func(ctx context.Context) (bool, error) {


### PR DESCRIPTION
The `CA Root Controller all namespaces should have valid configs in` test regularly flakes, causing CI to fail.

As a first step, try to reduce flakes by increasing this timeout, on the assumption that the flakes are caused by a heavy load in CI or some other thing which causes them to time out.

Also:

- Changes to use variables when calling the `Poll` function, which makes the arguments clearer to reason about.
- Adds `no-color` to ginkgo when running in CI to make output more readable
