### PR TITLE
Disable kubernetes client side rate limiting

### DIFF
--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -152,6 +152,12 @@ func (o *Options) addFlags(cmd *cobra.Command) {
 	o.addCertManagerFlags(nfs.FlagSet("cert-manager"))
 	o.kubeConfigFlags = genericclioptions.NewConfigFlags(true)
 	o.kubeConfigFlags.AddFlags(nfs.FlagSet("Kubernetes"))
+	o.kubeConfigFlags.WrapConfigFn = func(c *rest.Config) *rest.Config {
+		// Trust that K8s server side API Priority and Fairness is enabled
+		c.QPS = -1
+		c.Burst = -1
+		return c
+	}
 	o.addTLSFlags(nfs.FlagSet("TLS"))
 	o.addServerFlags(nfs.FlagSet("Server"))
 	o.addControllerFlags(nfs.FlagSet("controller"))

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -360,6 +360,15 @@ If set, limit where istio-csr creates configmaps with root ca certificates. If u
 Example: maistra.io/member-of=istio-system
 
 
+#### **app.controller.disableKubernetesClientRateLimiter** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+Allows you to disable the default Kubernetes client rate limiter if istio-csr is exceeding the default QPS (5) and Burst (10) limits. For example in large clusters with many Istio workloads, restarting the Pods may cause istio-csr to send bursts Kubernetes API requests that exceed the limits of the default Kubernetes client rate limiter and istio-csr will become slow to issue certificates for your workloads. Only disable client rate limiting if the Kubernetes API server supports  
+[API Priority and Fairness](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/),  
+to avoid overloading the server.
 #### **volumes** ~ `array`
 > Default value:
 > ```yaml

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -90,6 +90,7 @@ spec:
           {{- if .Values.app.controller.configmapNamespaceSelector }}
           - "--configmap-namespace-selector={{ .Values.app.controller.configmapNamespaceSelector }}"
           {{- end }}
+          - "--disable-kubernetes-client-rate-limiter={{ .Values.app.controller.disableKubernetesClientRateLimiter }}"
 
           - "--runtime-issuance-config-map-name={{.Values.app.runtimeIssuanceConfigMap}}"
           - "--runtime-issuance-config-map-namespace={{.Release.Namespace}}"

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -159,6 +159,9 @@
         "configmapNamespaceSelector": {
           "$ref": "#/$defs/helm-values.app.controller.configmapNamespaceSelector"
         },
+        "disableKubernetesClientRateLimiter": {
+          "$ref": "#/$defs/helm-values.app.controller.disableKubernetesClientRateLimiter"
+        },
         "leaderElectionNamespace": {
           "$ref": "#/$defs/helm-values.app.controller.leaderElectionNamespace"
         }
@@ -168,6 +171,11 @@
     "helm-values.app.controller.configmapNamespaceSelector": {
       "description": "If set, limit where istio-csr creates configmaps with root ca certificates. If unset, configmap created in ALL namespaces.\nExample: maistra.io/member-of=istio-system",
       "type": "string"
+    },
+    "helm-values.app.controller.disableKubernetesClientRateLimiter": {
+      "default": false,
+      "description": "Allows you to disable the default Kubernetes client rate limiter if istio-csr is exceeding the default QPS (5) and Burst (10) limits. For example in large clusters with many Istio workloads, restarting the Pods may cause istio-csr to send bursts Kubernetes API requests that exceed the limits of the default Kubernetes client rate limiter and istio-csr will become slow to issue certificates for your workloads. Only disable client rate limiting if the Kubernetes API server supports\n[API Priority and Fairness](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/),\nto avoid overloading the server.",
+      "type": "boolean"
     },
     "helm-values.app.controller.leaderElectionNamespace": {
       "default": "istio-system",

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -195,6 +195,17 @@ app:
     # +docs:property
     # configmapNamespaceSelector:
 
+    # Allows you to disable the default Kubernetes client rate limiter if
+    # istio-csr is exceeding the default QPS (5) and Burst (10) limits.
+    # For example in large clusters with many Istio workloads, restarting the Pods may cause
+    # istio-csr to send bursts Kubernetes API requests that exceed the limits of
+    # the default Kubernetes client rate limiter and istio-csr will become slow to issue
+    # certificates for your workloads.
+    # Only disable client rate limiting if the Kubernetes API server supports
+    # [API Priority and Fairness](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/),
+    # to avoid overloading the server.
+    disableKubernetesClientRateLimiter: false
+
 # Optional extra volumes. Useful for mounting custom root CAs
 #
 # For example:

--- a/make/test-e2e.mk
+++ b/make/test-e2e.mk
@@ -68,6 +68,7 @@ test-e2e-deps: INSTALL_OPTIONS :=
 test-e2e-deps: INSTALL_OPTIONS += --set image.repository=$(oci_manager_image_name_development)
 test-e2e-deps: INSTALL_OPTIONS += --set app.runtimeIssuanceConfigMap=$(E2E_RUNTIME_CONFIG_MAP_NAME)
 test-e2e-deps: INSTALL_OPTIONS += --set app.logFormat=json
+test-e2e-deps: INSTALL_OPTIONS += --set app.controller.disableKubernetesClientRateLimiter=true
 test-e2e-deps: INSTALL_OPTIONS += -f ./make/config/istio-csr-values.yaml
 test-e2e-deps: e2e-setup-cert-manager
 test-e2e-deps: e2e-create-cert-manager-istio-resources


### PR DESCRIPTION
Trust that server side API Priority and Fairness is enabled on the cluster, which will provide server side rate limiting. This allows a single istio-csr pod to serve larger bursts of traffic, such as when a large number of pods restart.

Fixes #144
Fixes #217