### PR TITLE
add flag to set log-format

### DIFF
--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -87,6 +87,13 @@ Service nodePort to expose istio-csr gRPC service.
 > ```
 
 Verbosity of istio-csr logging.
+#### **app.logFormat** ~ `string`
+> Default value:
+> ```yaml
+> text
+> ```
+
+Output format of istio-csr logging.
 #### **app.metrics.port** ~ `number`
 > Default value:
 > ```yaml

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -48,6 +48,7 @@ spec:
           periodSeconds: 7
         args:
           - "--log-level={{.Values.app.logLevel}}"
+          - "--log-format={{.Values.app.logFormat}}"
           - "--metrics-port={{.Values.app.metrics.port}}"
           - "--readiness-probe-port={{.Values.app.readinessProbe.port}}"
           - "--readiness-probe-path={{.Values.app.readinessProbe.path}}"

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -65,6 +65,9 @@
         "istio": {
           "$ref": "#/$defs/helm-values.app.istio"
         },
+        "logFormat": {
+          "$ref": "#/$defs/helm-values.app.logFormat"
+        },
         "logLevel": {
           "$ref": "#/$defs/helm-values.app.logLevel"
         },
@@ -195,6 +198,11 @@
     },
     "helm-values.app.istio.revisions[0]": {
       "default": "default",
+      "type": "string"
+    },
+    "helm-values.app.logFormat": {
+      "default": "text",
+      "description": "Output format of istio-csr logging.",
       "type": "string"
     },
     "helm-values.app.logLevel": {

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -48,6 +48,9 @@ app:
   # Verbosity of istio-csr logging.
   logLevel: 1 # 1-5
 
+  # Output format of istio-csr logging.
+  logFormat: text # text or json
+
   metrics:
     # Port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'.
     port: 9402


### PR DESCRIPTION
I would like logs to be output in json format.

This uses the same logs api libraries as cert-manager itself,
though it doesn't expose the full logging configuration surface,
just an extra `--log-format` flag.

Example original output:

```
I0718 21:24:43.654238   65256 options.go:113] "------------------------------------------------------------------------------------------------------------"
I0718 21:24:43.654292   65256 options.go:114] "WARNING!: --root-ca-file is not defined which means the root CA will be discovered by the configured issuer."
I0718 21:24:43.654298   65256 options.go:115] "WARNING!: It is strongly recommended that a root CA bundle be statically defined."
I0718 21:24:43.654303   65256 options.go:116] "------------------------------------------------------------------------------------------------------------"
I0718 21:24:43.657170   65256 server.go:208] "Starting metrics server" logger="controller-runtime.metrics"
I0718 21:24:43.657222   65256 server.go:247] "Serving metrics server" logger="controller-runtime.metrics" bindAddress="0.0.0.0:9402" secure=false
I0718 21:24:43.657319   65256 server.go:83] "starting server" name="health probe" addr="[::]:6060"
I0718 21:24:43.657582   65256 leaderelection.go:250] attempting to acquire leader lease istio-system/istio-csr...
I0718 21:24:43.933090   65256 internal.go:525] "Stopping and waiting for non leader election runnables" logger="manager"
I0718 21:24:43.933159   65256 internal.go:529] "Stopping and waiting for leader election runnables" logger="manager"
I0718 21:24:43.933176   65256 internal.go:537] "Stopping and waiting for caches" logger="manager"
I0718 21:24:43.933216   65256 internal.go:541] "Stopping and waiting for webhooks" logger="manager"
I0718 21:24:43.933239   65256 internal.go:544] "Stopping and waiting for HTTP servers" logger="manager"
I0718 21:24:43.933283   65256 server.go:68] "shutting down server" name="health probe" addr="[::]:6060"
E0718 21:24:43.933364   65256 internal.go:499] "error received after stop sequence was engaged" err="context canceled" logger="manager"
I0718 21:24:43.933399   65256 server.go:254] "Shutting down metrics server with timeout of 1 minute" logger="controller-runtime.metrics"
I0718 21:24:43.933575   65256 internal.go:548] "Wait completed, proceeding to shutdown the manager" logger="manager"
E0718 21:24:43.933702   65256 leaderelection.go:351] error initially creating leader election record: Post "https://justia.liao.dev:6443/apis/coordination.k8s.io/v1/namespaces/istio-system/leases": context canceled
Error: failed to fetch initial serving certificate: failed to sign serving certificate: failed to create CertificateRequest: namespaces "istio-system" not found
E0718 21:24:43.933794   65256 internal.go:499] "error received after stop sequence was engaged" err="leader election lost" logger="manager"
```

Example output with `--log-format json`:

```
{"ts":1721334309231.8687,"caller":"options/options.go:113","msg":"------------------------------------------------------------------------------------------------------------","v":0}
{"ts":1721334309231.8843,"caller":"options/options.go:114","msg":"WARNING!: --root-ca-file is not defined which means the root CA will be discovered by the configured issuer.","v":0}
{"ts":1721334309231.888,"caller":"options/options.go:115","msg":"WARNING!: It is strongly recommended that a root CA bundle be statically defined.","v":0}
{"ts":1721334309231.891,"caller":"options/options.go:116","msg":"------------------------------------------------------------------------------------------------------------","v":0}
{"ts":1721334309233.4988,"logger":"controller-runtime.metrics","caller":"server/server.go:208","msg":"Starting metrics server","v":0}
{"ts":1721334309233.5322,"logger":"controller-runtime.metrics","caller":"server/server.go:247","msg":"Serving metrics server","v":0,"bindAddress":"0.0.0.0:9402","secure":false}
{"ts":1721334309233.554,"caller":"manager/server.go:83","msg":"starting server","name":"health probe","addr":"[::]:6060","v":0}
{"ts":1721334309233.7185,"caller":"leaderelection/leaderelection.go:250","msg":"attempting to acquire leader lease istio-system/istio-csr...","v":0}
{"ts":1721334309476.7566,"logger":"manager","caller":"manager/internal.go:525","msg":"Stopping and waiting for non leader election runnables","v":0}
{"ts":1721334309476.9492,"logger":"manager","caller":"manager/internal.go:529","msg":"Stopping and waiting for leader election runnables","v":0}
{"ts":1721334309477.0334,"logger":"manager","caller":"manager/internal.go:537","msg":"Stopping and waiting for caches","v":0}
{"ts":1721334309477.0322,"logger":"manager","caller":"manager/internal.go:499","msg":"error received after stop sequence was engaged","err":"context canceled"}
{"ts":1721334309477.069,"logger":"manager","caller":"manager/internal.go:541","msg":"Stopping and waiting for webhooks","v":0}
{"ts":1721334309477.0898,"logger":"manager","caller":"manager/internal.go:544","msg":"Stopping and waiting for HTTP servers","v":0}
{"ts":1721334309477.158,"caller":"manager/server.go:68","msg":"shutting down server","name":"health probe","addr":"[::]:6060","v":0}
{"ts":1721334309477.2427,"logger":"controller-runtime.metrics","caller":"server/server.go:254","msg":"Shutting down metrics server with timeout of 1 minute","v":0}
{"ts":1721334309477.3958,"logger":"manager","caller":"manager/internal.go:548","msg":"Wait completed, proceeding to shutdown the manager","v":0}
{"ts":1721334309477.5764,"caller":"leaderelection/leaderelection.go:351","msg":"error initially creating leader election record: Post \"https://justia.liao.dev:6443/apis/coordination.k8s.io/v1/namespaces/istio-system/leases\": context canceled"}
Error: failed to fetch initial serving certificate: failed to sign serving certificate: failed to create CertificateRequest: namespaces "istio-system" not found
{"ts":1721334309477.7253,"logger":"manager","caller":"manager/internal.go:499","msg":"error received after stop sequence was engaged","err":"leader election lost"}
```