### PR TITLE
Add ability to dynamically configure istiod cert

### DIFF
--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/cert-manager/istio-csr/pkg/certmanager"
+	"github.com/cert-manager/istio-csr/pkg/istiodcert"
 	"github.com/cert-manager/istio-csr/pkg/server"
 	"github.com/cert-manager/istio-csr/pkg/tls"
 
@@ -64,6 +65,7 @@ type Options struct {
 	CertManager certmanager.Options
 	TLS         tls.Options
 	Server      server.Options
+	IstiodCert  istiodcert.Options
 }
 
 // OptionsController is the Controller specific options
@@ -142,6 +144,11 @@ func (o *Options) Complete() error {
 		log.Info("WARNING: --preserve-certificate-requests is enabled. Do not enable this option in production, or environments with any non-trivial number of workloads for an extended period of time. Doing so will balloon the resource consumption of ETCD, the API server, and istio-csr, leading to errors and slowdown. This option is intended for debugging purposes only, for limited periods of time.")
 	}
 
+	err = o.IstiodCert.Validate()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -156,6 +163,8 @@ func (o *Options) addFlags(cmd *cobra.Command) {
 	o.addServerFlags(nfs.FlagSet("Server"))
 	o.addControllerFlags(nfs.FlagSet("controller"))
 	o.addAdditionalAnnotationsFlags(nfs.FlagSet("additional-annotations"))
+
+	istiodcert.AddFlags(&o.IstiodCert, nfs.FlagSet("istiod-cert"))
 
 	usageFmt := "Usage:\n  %s\n"
 	cmd.SetUsageFunc(func(cmd *cobra.Command) error {

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -250,13 +250,14 @@ An optional file location to a PEM encoded root CA that the root CA. ConfigMap i
 Requested duration of gRPC serving certificate. Will be automatically renewed.  
 Based on NIST 800-204A recommendations (SM-DR13).  
 https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf
-#### **app.tls.istiodCertificateEnable** ~ `bool`
+#### **app.tls.istiodCertificateEnable** ~ `boolean,string,null`
 > Default value:
 > ```yaml
 > true
 > ```
 
-Create the default certificate as part of install.
+If true, create the istiod certificate using a cert-manager certificate as part of the install. If set to "dynamic", will create the cert dynamically when istio-csr pods start up. If false, no cert is created.
+
 #### **app.tls.istiodCertificateDuration** ~ `string`
 > Default value:
 > ```yaml

--- a/deploy/charts/istio-csr/templates/certificate.yaml
+++ b/deploy/charts/istio-csr/templates/certificate.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.app.tls.istiodCertificateEnable }}
+{{- if eq (toString .Values.app.tls.istiodCertificateEnable) "true" }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/deploy/charts/istio-csr/templates/clusterrole.yaml
+++ b/deploy/charts/istio-csr/templates/clusterrole.yaml
@@ -21,3 +21,13 @@ rules:
   - "tokenreviews"
   verbs:
   - "create"
+{{- if eq (toString .Values.app.tls.istiodCertificateEnable) "dynamic" }}
+- apiGroups:
+  - "cert-manager.io"
+  resources:
+  - "certificates"
+  verbs:
+  - "list"
+  - "get"
+  - "watch"
+{{- end }}

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -93,6 +93,17 @@ spec:
 
           - "--runtime-issuance-config-map-name={{.Values.app.runtimeIssuanceConfigMap}}"
           - "--runtime-issuance-config-map-namespace={{.Release.Namespace}}"
+
+          # dynamic istiod cert
+          - "--istiod-cert-enabled={{ eq (toString .Values.app.tls.istiodCertificateEnable) "dynamic" }}"
+          - "--istiod-cert-name=istiod-dynamic"
+          - "--istiod-cert-namespace={{ .Values.app.istio.namespace }}"
+          - "--istiod-cert-duration={{ .Values.app.tls.istiodCertificateDuration }}"
+          - "--istiod-cert-renew-before={{ .Values.app.tls.istiodCertificateRenewBefore }}"
+          - "--istiod-cert-key-algorithm={{ default .Values.app.server.serving.signatureAlgorithm .Values.app.tls.istiodPrivateKeyAlgorithm }}"
+          - "--istiod-cert-key-size={{ .Values.app.tls.istiodPrivateKeySize }}"
+          - "--istiod-cert-additional-dns-names={{ join "," .Values.app.tls.istiodAdditionalDNSNames }}"
+          - "--istiod-cert-istio-revisions={{ join "," .Values.app.istio.revisions }}"
         {{- if .Values.volumeMounts }}
         volumeMounts:
 {{ toYaml .Values.volumeMounts | indent 10 }}

--- a/deploy/charts/istio-csr/templates/role.yaml
+++ b/deploy/charts/istio-csr/templates/role.yaml
@@ -26,4 +26,16 @@ rules:
   verbs: ["get", "list", "watch"]
   resourceNames: ["{{.Values.app.runtimeIssuanceConfigMap}}"]
 {{- end }}
-
+{{- if eq (toString .Values.app.tls.istiodCertificateEnable) "dynamic" }}
+- apiGroups:
+  - "cert-manager.io"
+  resources:
+  - "certificates"
+  verbs:
+  - "get"
+  - "create"
+  - "update"
+  - "delete"
+  - "watch"
+  - "list"
+{{- end }}

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -452,8 +452,7 @@
     },
     "helm-values.app.tls.istiodCertificateEnable": {
       "default": true,
-      "description": "Create the default certificate as part of install.",
-      "type": "boolean"
+      "description": "If true, create the istiod certificate using a cert-manager certificate as part of the install. If set to \"dynamic\", will create the cert dynamically when istio-csr pods start up. If false, no cert is created."
     },
     "helm-values.app.tls.istiodCertificateRenewBefore": {
       "default": "30m",

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -134,7 +134,10 @@ app:
     # https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf
     certificateDuration: 1h
 
-    # Create the default certificate as part of install.
+    # If true, create the istiod certificate using a cert-manager certificate as part
+    # of the install. If set to "dynamic", will create the cert dynamically when
+    # istio-csr pods start up. If false, no cert is created.
+    # +docs:type=boolean,string,null
     istiodCertificateEnable: true
     # Requested duration of istio's Certificate. Will be automatically renewed.
     # Default is based on NIST 800-204A recommendations (SM-DR13).

--- a/make/config/istio-csr-pure-runtime-values.yaml
+++ b/make/config/istio-csr-pure-runtime-values.yaml
@@ -1,0 +1,45 @@
+replicaCount: 2
+
+service:
+  port: 443
+  type: NodePort
+  nodePort: 30443
+
+app:
+  logFormat: json
+  logLevel: 5
+
+  certmanager:
+    namespace: istio-system
+    # WARNING: do not enable this option in production, or environments with
+    # any non-trivial number of workloads for an extended period of time. Doing
+    # so will balloon the resource consumption of both ETCD and the API server,
+    # leading to errors and slow down. This option is intended for debugging
+    # purposes only, for limited periods of time.
+    preserveCertificateRequests: true
+    additionalAnnotations:
+    - name: custom.cert-manager.io/policy-name
+      value: istio-csr
+    issuer:
+      # Explicitly blanked out to test "pure" runtime configuration
+      group: ""
+      kind: ""
+      name: ""
+
+  tls:
+    trustDomain: foo.bar
+    istiodCertificateEnable: "dynamic"
+    certificateDuration: 20s
+    certificateDNSNames:
+    # Name used by the e2e client
+    - istio-csr.cert-manager.svc
+    # Name used within the demo cluster
+    - cert-manager-istio-csr.cert-manager.svc
+
+  server:
+    maxCertificateDuration: 5m
+    serving:
+      address: 0.0.0.0
+      port: 6443
+
+resources: {}

--- a/make/test-e2e.mk
+++ b/make/test-e2e.mk
@@ -48,11 +48,25 @@ e2e-create-cert-manager-istio-resources: | kind-cluster e2e-setup-cert-manager $
 	$(KUBECTL) create namespace istio-system || true
 	$(KUBECTL) -n istio-system apply --server-side -f ./make/config/cert-manager-bootstrap-resources.yaml
 
+.PHONY: e2e-create-cert-manager-istio-pure-runtime-resources
+e2e-create-cert-manager-istio-pure-runtime-resources: | kind-cluster e2e-setup-cert-manager $(NEEDS_KUBECTL)
+	$(KUBECTL) apply -f test/e2e-pure-runtime/initial-manifests/configmap.yaml
+
+is_e2e_test=
+
 # The "install" target can be run on its own with any currently active cluster,
 # we can't use any other cluster then a target containing "test-e2e" is run.
-# When a "test-e2e" target is run, the currently active cluster must be the kind
+# When a "test-e2e*" target is run, the currently active cluster must be the kind
 # cluster created by the "kind-cluster" target.
 ifeq ($(findstring test-e2e,$(MAKECMDGOALS)),test-e2e)
+is_e2e_test = yes
+endif
+
+ifeq ($(findstring test-e2e-pure-runtime,$(MAKECMDGOALS)),test-e2e-pure-runtime)
+is_e2e_test = yes
+endif
+
+ifdef is_e2e_test
 install: kind-cluster oci-load-manager e2e-create-cert-manager-istio-resources
 endif
 
@@ -93,6 +107,32 @@ test-e2e: test-e2e-deps | kind-cluster $(NEEDS_GINKGO) $(NEEDS_KUBECTL)
 		--junit-report=junit-go-e2e.xml \
 		$(EXTRA_GINKGO_FLAGS) \
 		./test/e2e/ \
+		-ldflags $(go_manager_ldflags) \
+		-- \
+		--istioctl-path $(CURDIR)/$(bin_dir)/scratch/istioctl-$(ISTIO_VERSION) \
+		--kubeconfig-path $(CURDIR)/$(kind_kubeconfig) \
+		--kubectl-path $(KUBECTL) \
+		--runtime-issuance-config-map-name=$(E2E_RUNTIME_CONFIG_MAP_NAME)
+
+test-e2e-pure-runtime-deps: INSTALL_OPTIONS :=
+test-e2e-pure-runtime-deps: INSTALL_OPTIONS += --set image.repository=$(oci_manager_image_name_development)
+test-e2e-pure-runtime-deps: INSTALL_OPTIONS += --set app.runtimeIssuanceConfigMap=$(E2E_RUNTIME_CONFIG_MAP_NAME)
+test-e2e-pure-runtime-deps: INSTALL_OPTIONS += -f ./make/config/istio-csr-pure-runtime-values.yaml
+test-e2e-pure-runtime-deps: e2e-setup-cert-manager
+test-e2e-pure-runtime-deps: e2e-create-cert-manager-istio-resources
+test-e2e-pure-runtime-deps: e2e-create-cert-manager-istio-pure-runtime-resources
+test-e2e-pure-runtime-deps: install
+test-e2e-pure-runtime-deps: e2e-setup-istio
+
+# "Pure" runtime configuration e2e tests require different installation values
+.PHONY: test-e2e-pure-runtime
+test-e2e-pure-runtime: test-e2e-pure-runtime-deps | kind-cluster $(NEEDS_GINKGO) $(NEEDS_KUBECTL)
+	$(GINKGO) \
+		--output-dir=$(ARTIFACTS) \
+		--focus="$(E2E_FOCUS)" \
+		--junit-report=junit-go-e2e.xml \
+		$(EXTRA_GINKGO_FLAGS) \
+		./test/e2e-pure-runtime/ \
 		-ldflags $(go_manager_ldflags) \
 		-- \
 		--istioctl-path $(CURDIR)/$(bin_dir)/scratch/istioctl-$(ISTIO_VERSION) \

--- a/pkg/istiodcert/options.go
+++ b/pkg/istiodcert/options.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package istiodcert
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/spf13/pflag"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
+)
+
+const (
+	// minRSAKeySize is the minimum allowed RSA key size for the istiod certificate
+	minRSAKeySize int = 2048
+)
+
+// Options holds various configuration options for generating the istiod certificate
+type Options struct {
+	Enabled bool
+
+	CertificateName      string
+	CertificateNamespace string
+
+	Duration    time.Duration
+	RenewBefore time.Duration
+
+	KeyAlgorithm string
+	KeySize      int
+
+	CMKeyAlgorithm cmapi.PrivateKeyAlgorithm
+
+	AdditionalDNSNames []string
+
+	IstioRevisions []string
+}
+
+// Validate confirms that the given istiod cert options are valid
+func (o *Options) Validate() error {
+	// no point in validating if the config won't be used
+	if !o.Enabled {
+		return nil
+	}
+
+	var errs []error
+
+	if o.RenewBefore.Nanoseconds() >= o.Duration.Nanoseconds() {
+		errs = append(errs, fmt.Errorf("istiod certificate renew-before %s must be smaller than the requested duration %s", o.RenewBefore.String(), o.Duration.String()))
+	}
+
+	o.KeyAlgorithm = strings.ToUpper(o.KeyAlgorithm)
+
+	switch o.KeyAlgorithm {
+	case "RSA":
+		o.CMKeyAlgorithm = cmapi.RSAKeyAlgorithm
+
+		if o.KeySize == 0 {
+			o.KeySize = minRSAKeySize
+		}
+
+		if o.KeySize < minRSAKeySize {
+			errs = append(errs, fmt.Errorf("istio certificate RSA key size must be at least %d bits, but got %d", minRSAKeySize, o.KeySize))
+		}
+
+	case "ECDSA":
+		o.CMKeyAlgorithm = cmapi.ECDSAKeyAlgorithm
+
+		if o.KeySize == 0 {
+			o.KeySize = 256
+		}
+
+		if o.KeySize != 256 && o.KeySize != 384 {
+			errs = append(errs, fmt.Errorf("istio certificate private key of type ECDSA must have 'size' equal to either 256 or 384"))
+		}
+
+	default:
+		errs = append(errs, fmt.Errorf("invalid key algorithm %q; valid values are RSA and ECDSA", o.KeyAlgorithm))
+	}
+
+	if len(o.AdditionalDNSNames) > 0 {
+		for _, name := range o.AdditionalDNSNames {
+			// IsDNS1123Subdomain is equivalent to "IsValidDNSName"
+			// This validation function returns a slice of strings if there was an error
+			validationErrors := k8svalidation.IsDNS1123Subdomain(name)
+			if len(validationErrors) > 0 {
+				errs = append(errs, fmt.Errorf("invalid additional DNS name %q: ", strings.Join(validationErrors, ", ")))
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func AddFlags(o *Options, fs *pflag.FlagSet) {
+	fs.BoolVar(&o.Enabled, "istiod-cert-enabled", false, "Whether to dynamically provision the istiod certificate")
+
+	fs.StringVar(&o.CertificateName, "istiod-cert-name", "istiod-dynamic", "Name of the Certificate resource to use for dynamic istiod provisioning")
+
+	fs.StringVar(&o.CertificateNamespace, "istiod-cert-namespace", "istio-system", "Namespace for the dynamic istiod cert")
+
+	fs.DurationVar(&o.Duration, "istiod-cert-duration", time.Hour,
+		"Requested duration of the istiod certificate, if enabled")
+
+	fs.DurationVar(&o.RenewBefore, "istiod-cert-renew-before", 30*time.Minute,
+		"How long to wait before trying to renew the istiod certificate (if enabled). Must be less than duration.")
+
+	fs.StringVar(&o.KeyAlgorithm, "istiod-cert-key-algorithm", "RSA", "Key algorithm to use for the istiod cert. Can be RSA or ECDSA.")
+
+	fs.IntVar(&o.KeySize, "istiod-cert-key-size", minRSAKeySize,
+		fmt.Sprintf("Parameter for istiod certificate key. For RSA, must be a number of bits >= %d. For ECDSA, can only be 256 or 384, corresponding to P-256 and P-384 respectively.", minRSAKeySize))
+
+	fs.StringSliceVar(&o.AdditionalDNSNames, "istiod-cert-additional-dns-names", []string{}, "Additional DNS names to use for istiod cert (if enabled). Useful if istiod needs to be accessible outside of the cluster")
+
+	fs.StringSliceVar(&o.IstioRevisions, "istiod-cert-istio-revisions", []string{}, "A list of istio revisions which should have DNS SAN entries in the dynamic istiod cert")
+}

--- a/pkg/istiodcert/worker.go
+++ b/pkg/istiodcert/worker.go
@@ -1,0 +1,277 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package istiodcert
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmversioned "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
+	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1"
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/cert-manager/istio-csr/pkg/certmanager"
+)
+
+// DynamicIstiodCertProvisioner is both:
+// 1. A controller-runtime controller for watching the dynamic istiod cert and keeping it updated
+// 2. A wrapper around ctrlmgr.Runnable for listening for issuer changes and notifying the certificate controller
+type DynamicIstiodCertProvisioner struct {
+	log               logr.Logger
+	certManagerClient cmclient.CertificateInterface
+	opts              Options
+
+	initialIssuerRef *cmmeta.ObjectReference
+	issuerRef        *cmmeta.ObjectReference
+
+	issuerRefMutex sync.Mutex
+
+	issuerChangeChan <-chan *cmmeta.ObjectReference
+
+	reconcileChan chan event.GenericEvent
+
+	trustDomain string
+}
+
+// New creates a DynamicIstiodCertProvisioner, ready to be added to a controller manager
+func New(log logr.Logger, restConfig *rest.Config, opts Options, issuerChangeNotifier certmanager.IssuerChangeNotifier, trustDomain string) (*DynamicIstiodCertProvisioner, error) {
+	cmClient, err := cmversioned.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build cert-manager client: %s", err)
+	}
+
+	initialIssuerRef := issuerChangeNotifier.InitialIssuer()
+
+	return &DynamicIstiodCertProvisioner{
+		log:               log,
+		certManagerClient: cmClient.CertmanagerV1().Certificates(opts.CertificateNamespace),
+		opts:              opts,
+
+		initialIssuerRef: initialIssuerRef,
+		issuerRef:        initialIssuerRef,
+
+		issuerRefMutex: sync.Mutex{},
+
+		issuerChangeChan: issuerChangeNotifier.SubscribeIssuerChange(),
+
+		reconcileChan: make(chan event.GenericEvent),
+
+		trustDomain: trustDomain,
+	}, nil
+}
+
+// Start makes DynamicIstiodCertProvisioner a Runnable which can be invoked by a manager.
+// It waits for a notification of an issuer change, and when it gets one it
+// triggers reconciliation of the dynamic istiod cert.
+func (dicp *DynamicIstiodCertProvisioner) Start(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			dicp.log.Info("Received context cancellation, shutting down dynamic istiod cert provisioner")
+			return nil
+
+		case newIssuer := <-dicp.issuerChangeChan:
+			dicp.handleNewIssuer(newIssuer)
+		}
+	}
+}
+
+// NeedLeaderElection returns true, because the DynamicIstiodCertProvisioner should only run in one pod
+// to avoid multiple pods trying to change the same certificate.
+func (dicp *DynamicIstiodCertProvisioner) NeedLeaderElection() bool {
+	return true
+}
+
+func (dicp *DynamicIstiodCertProvisioner) handleNewIssuer(issuerRef *cmmeta.ObjectReference) {
+	dicp.issuerRefMutex.Lock()
+	defer dicp.issuerRefMutex.Unlock()
+
+	if issuerRef == nil && dicp.initialIssuerRef != nil {
+		// don't blank out the issuer if there's an initial ref; use that instead
+		dicp.issuerRef = dicp.initialIssuerRef
+		return
+	}
+
+	dicp.issuerRef = issuerRef
+
+	dicp.log.Info("triggering reconciliation of istiod cert after issuer change", "cert_name", dicp.opts.CertificateName, "cert_namespace", dicp.opts.CertificateNamespace)
+
+	dicp.reconcileChan <- event.GenericEvent{
+		Object: &cmapi.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dicp.opts.CertificateName,
+				Namespace: dicp.opts.CertificateNamespace,
+			},
+		},
+	}
+}
+
+// AddControllersToManager adds controllers to the given manager which:
+// 1. Handle provisioning and updating the dynamic istiod cert
+// 2. Handle listening for updates to the active issuer ref and re-issuing
+func (dicp *DynamicIstiodCertProvisioner) AddControllersToManager(mgr manager.Manager) error {
+	b := ctrl.NewControllerManagedBy(mgr)
+
+	b.For(
+		new(cmapi.Certificate), builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
+			// Only process one specific cert which was requested
+			return obj.GetName() == dicp.opts.CertificateName && obj.GetNamespace() == dicp.opts.CertificateNamespace
+		})))
+
+	// when the issuer changes, trigger a re-reconciliation
+	b.WatchesRawSource(source.Channel(dicp.reconcileChan, handler.EnqueueRequestsFromMapFunc(
+		func(context.Context, client.Object) []reconcile.Request {
+			return []reconcile.Request{ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      dicp.opts.CertificateName,
+					Namespace: dicp.opts.CertificateNamespace,
+				},
+			}}
+		})))
+
+	err := b.Complete(dicp)
+	if err != nil {
+		return err
+	}
+
+	err = mgr.Add(dicp)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (dicp *DynamicIstiodCertProvisioner) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	dicp.issuerRefMutex.Lock()
+	defer dicp.issuerRefMutex.Unlock()
+
+	if dicp.issuerRef == nil {
+		dicp.log.Info("exiting reconcile of dynamic istiod early; no issuerRef is set")
+		return ctrl.Result{}, nil
+	}
+
+	dicp.log.Info("reconciling dynamic istiod cert", "issuer-name", dicp.issuerRef.Name, "issuer-kind", dicp.issuerRef.Kind, "issuer-group", dicp.issuerRef.Group)
+
+	spiffeID := fmt.Sprintf("spiffe://%s/ns/%s/sa/istiod-service-account", dicp.trustDomain, req.Namespace)
+
+	commonName, dnsNames := makeDNSNamesFromRevisions(req.Namespace, dicp.opts.IstioRevisions)
+
+	if len(dicp.opts.AdditionalDNSNames) > 0 {
+		dnsNames = append(dnsNames, dicp.opts.AdditionalDNSNames...)
+	}
+
+	desiredSpec := cmapi.CertificateSpec{
+		CommonName:  commonName,
+		DNSNames:    dnsNames,
+		URIs:        []string{spiffeID},
+		SecretName:  "istiod-tls",
+		Duration:    &metav1.Duration{Duration: dicp.opts.Duration},
+		RenewBefore: &metav1.Duration{Duration: dicp.opts.RenewBefore},
+		PrivateKey: &cmapi.CertificatePrivateKey{
+			RotationPolicy: cmapi.RotationPolicyAlways,
+			Algorithm:      dicp.opts.CMKeyAlgorithm,
+			Size:           dicp.opts.KeySize,
+		},
+		RevisionHistoryLimit: ptr.To(int32(1)),
+		IssuerRef:            *dicp.issuerRef,
+	}
+
+	cert, err := dicp.certManagerClient.Get(ctx, req.Name, metav1.GetOptions{})
+
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("failed to fetch cert: %s", err)
+		}
+
+		cert := cmapi.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      req.Name,
+				Namespace: req.Namespace,
+			},
+			Spec: desiredSpec,
+		}
+
+		_, err = dicp.certManagerClient.Create(ctx, &cert, metav1.CreateOptions{})
+		return ctrl.Result{}, err
+	}
+
+	cert.Spec = desiredSpec
+
+	_, err = dicp.certManagerClient.Update(ctx, cert, metav1.UpdateOptions{})
+	return ctrl.Result{}, err
+}
+
+// makeDNSNamesFromRevisions takes a list of istio revisions and produces a list of
+// corresponding DNS names for the istiod cert, as well as returning the value for the common name
+func makeDNSNamesFromRevisions(namespace string, istioRevisions []string) (string, []string) {
+	if len(istioRevisions) == 0 {
+		// It's unlikely to have no revisisions since the default is to have a
+		// list of revisions containing just "default".
+		// In any case, treat an empty list of revisions as being the same as just
+		// the default revision.
+		istioRevisions = []string{"default"}
+	}
+
+	var dnsNames []string
+
+	// The default revision is a special case, and "default" isn't added to the DNS SAN, appearing as simply
+	// istiod.<namespace>.svc
+	defaultSAN := fmt.Sprintf("istiod.%s.svc", namespace)
+
+	for _, revision := range istioRevisions {
+		if revision == "default" {
+			dnsNames = append(dnsNames, defaultSAN)
+			continue
+		}
+
+		dnsNames = append(dnsNames, fmt.Sprintf("istiod%s.%s.svc", revision, namespace))
+	}
+
+	// Always return the default SAN as the commonName to match the behaviour of the static istiod cert
+	// defined in the Helm chart.
+
+	// It seems likely that we could do better here in the future and pick a commonName from the list of SANs we
+	// created from the list of revisions, since there's a warning in the default values.yaml file about this:
+
+	// > The common name for the istiod certificate is hard coded to the `default` revision DNS name.
+	// > Some issuers may require that the common name on certificates match one
+	// > of the DNS names. If:
+	// > 1. Your issuer has this constraint, and
+	// > 2. You are not using `default` as a revision,
+	// > add the `default` revision here anyway. The resulting certificate will include a DNS name that won't be
+	// > used, but will pass this constraint.
+
+	return defaultSAN, dnsNames
+}

--- a/test/e2e-pure-runtime/e2e_test.go
+++ b/test/e2e-pure-runtime/e2e_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"flag"
+	"testing"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/cert-manager/istio-csr/test/e2e/framework/config"
+
+	_ "github.com/cert-manager/istio-csr/test/e2e-pure-runtime/suite"
+)
+
+func init() {
+	config.GetConfig().AddFlags(flag.CommandLine)
+
+	wait.ForeverTestTimeout = time.Second * 60
+}
+
+func TestE2E(t *testing.T) {
+	flag.Parse()
+
+	gomega.RegisterFailHandler(ginkgo.Fail)
+
+	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
+
+	// Turn on verbose by default to get spec names
+	reporterConfig.Verbose = true
+	// Turn on EmitSpecProgress to get spec progress (especially on interrupt)
+	suiteConfig.EmitSpecProgress = true
+	// Randomize specs as well as suites
+	suiteConfig.RandomizeAllSpecs = true
+
+	ginkgo.RunSpecs(t, "cert-manager istio agent e2e suite (pure runtime)", suiteConfig, reporterConfig)
+}

--- a/test/e2e-pure-runtime/initial-manifests/README.md
+++ b/test/e2e-pure-runtime/initial-manifests/README.md
@@ -1,0 +1,1 @@
+"Initial" manifests are manifests which should be applied before any tests are run

--- a/test/e2e-pure-runtime/initial-manifests/configmap.yaml
+++ b/test/e2e-pure-runtime/initial-manifests/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: runtime-config-map
+  namespace: cert-manager
+data:
+  issuer-group: cert-manager.io
+  issuer-kind: Issuer
+  issuer-name: istio-ca

--- a/test/e2e-pure-runtime/manifests/issuer.yaml
+++ b/test/e2e-pure-runtime/manifests/issuer.yaml
@@ -1,0 +1,34 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: runtimeconfig-ca
+  namespace: istio-system
+spec:
+  isCA: true
+  commonName: runtimeconfig-ca
+  secretName: runtimeconfig-ca-secret
+  duration: 2160h # 90d
+  subject:
+    organizations:
+    - cluster.local
+    - cert-manager
+    organizationalUnits:
+    - runtimeconfig
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: istio-ca
+    kind: Issuer
+    group: cert-manager.io
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: runtimeconfig-ca-issuer
+  namespace: istio-system
+spec:
+  ca:
+    secretName: runtimeconfig-ca-secret

--- a/test/e2e-pure-runtime/manifests/sleep.yaml
+++ b/test/e2e-pure-runtime/manifests/sleep.yaml
@@ -1,0 +1,65 @@
+# Copyright Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+##################################################################################################
+# Sleep service
+##################################################################################################
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sleep
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sleep
+  labels:
+    app: sleep
+    service: sleep
+spec:
+  ports:
+  - port: 80
+    name: http
+  selector:
+    app: sleep
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sleep
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sleep
+  template:
+    metadata:
+      labels:
+        app: sleep
+    spec:
+      serviceAccountName: sleep
+      containers:
+      - image: quay.io/curl/curl:8.5.0
+        imagePullPolicy: Never
+        name: sleep
+        command: ["/bin/sleep", "3650d"]
+        volumeMounts:
+        - mountPath: /etc/sleep/tls
+          name: secret-volume
+      volumes:
+      - name: secret-volume
+        secret:
+          secretName: sleep-secret
+          optional: true
+---

--- a/test/e2e-pure-runtime/suite/suite.go
+++ b/test/e2e-pure-runtime/suite/suite.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package suite
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"time"
+
+	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmutil "github.com/cert-manager/cert-manager/pkg/util/pki"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/cert-manager/istio-csr/test/e2e/framework"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = framework.CasesDescribe("runtime configuration", func() {
+	f := framework.NewDefaultFramework("runtime-configuration")
+
+	var (
+		namespaceName = "pure-runtimeconfig-ns"
+
+		ctx = context.Background()
+	)
+
+	JustBeforeEach(func() {
+		_, err := f.KubeClientSet.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespaceName,
+				Labels: map[string]string{
+					"istio-injection": "enabled",
+				},
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating second issuer")
+		err = kubectl(f, "apply", "-f", "./manifests/issuer.yaml")
+		Expect(err).NotTo(HaveOccurred())
+
+		By(fmt.Sprintf("creating deployments in %s namespace", namespaceName))
+		err = kubectl(f, "apply", "-n", namespaceName, "-f", "./manifests/sleep.yaml")
+		Expect(err).NotTo(HaveOccurred())
+
+		By(fmt.Sprintf("waiting for sleep pods in %s namespace to become ready", namespaceName))
+		err = f.Helper().WaitForLabelledPodsReady(ctx, namespaceName, "app=sleep", time.Minute*10)
+		if err != nil {
+			err := kubectl(f, "describe", "-n", namespaceName, "pods")
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+
+	JustAfterEach(func() {
+		By(fmt.Sprintf("deleting %s namespace with deployments", namespaceName))
+
+		err := f.KubeClientSet.CoreV1().Namespaces().Delete(ctx, namespaceName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should use the runtime configured issuer for running pods", func() {
+		By("checking that already-created pods use the runtime configured issuer")
+		pods, err := f.KubeClientSet.CoreV1().Pods(namespaceName).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=sleep",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		if len(pods.Items) != 1 {
+			Expect(fmt.Errorf("expected single sleep pod in ns %q, got=%d", namespaceName, len(pods.Items))).NotTo(HaveOccurred())
+		}
+
+		istioCertChain, err := istioctlGetCert(f, pods.Items[0].Name, namespaceName)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(istioCertChain).To(HaveLen(2), "expected exactly 2 certificates for the running sleep pod chain")
+
+		Expect(istioCertChain[0].Issuer.OrganizationalUnit).To(BeEmpty(), "expected no OUs in running sleep pod's issuer")
+
+		By("checking for dynamic istiod cert")
+		istiodCertName := "istiod-dynamic"
+		istiodCertNamespace := "istio-system"
+
+		interval := 500 * time.Millisecond
+		timeout := 1 * time.Minute
+		pollImmediate := true
+
+		var certificate *v1.Certificate
+
+		pollErr := wait.PollUntilContextTimeout(ctx, interval, timeout, pollImmediate, func(ctx context.Context) (bool, error) {
+			var err error
+			certificate, err = f.CMClientSet.CertmanagerV1().Certificates(istiodCertNamespace).Get(ctx, istiodCertName, metav1.GetOptions{})
+			if nil != err {
+				certificate = nil
+				return false, fmt.Errorf("error getting Certificate %v: %v", istiodCertName, err)
+			}
+
+			return apiutil.CertificateHasCondition(certificate, cmapi.CertificateCondition{
+				Type:   cmapi.CertificateConditionReady,
+				Status: cmmeta.ConditionTrue,
+			}), nil
+		})
+		Expect(pollErr).NotTo(HaveOccurred())
+
+		Expect(certificate.Spec.IssuerRef.Name).To(Equal("istio-ca"))
+		Expect(certificate.Spec.IssuerRef.Kind).To(Equal("Issuer"))
+		Expect(certificate.Spec.IssuerRef.Group).To(Equal("cert-manager.io"))
+	})
+})
+
+// diveMap "dives" into a map, extracting another map from the given key and performing error checks
+func diveMap(m map[string]any, key string) (map[string]any, error) {
+	rawObject, exists := m[key]
+	if !exists {
+		return nil, fmt.Errorf("key %q not found in map", key)
+	}
+
+	innerMap, isMap := rawObject.(map[string]any)
+	if !isMap {
+		return nil, fmt.Errorf("key %q in map was not an object with string keys", key)
+	}
+
+	return innerMap, nil
+}
+
+func kubectl(f *framework.Framework, args ...string) error {
+	stdout, err := kubectlWithOutput(f, args...)
+
+	GinkgoWriter.Println(stdout)
+
+	return err
+}
+
+func kubectlWithOutput(f *framework.Framework, args ...string) (string, error) {
+	buf := &bytes.Buffer{}
+
+	// #nosec G204
+	cmd := exec.Command(f.Config().KubectlPath, args...)
+
+	cmd.Stdout = buf
+	cmd.Stderr = GinkgoWriter
+
+	err := cmd.Run()
+
+	return buf.String(), err
+}
+
+type IstioctlSecret struct {
+	Name        string         `json:"name"`
+	LastUpdated string         `json:"lastUpdated"`
+	Secret      map[string]any `json:"secret"`
+}
+
+type IstioctlJSONWrapper struct {
+	DynamicActiveSecrets []IstioctlSecret `json:"dynamicActiveSecrets"`
+}
+
+func istioctlGetCert(f *framework.Framework, podName string, namespaceName string) ([]*x509.Certificate, error) {
+	buf := &bytes.Buffer{}
+
+	// #nosec G204
+	cmd := exec.Command(f.Config().IstioctlPath, "proxy-config", "secrets", "-n", namespaceName, podName, "-ojson")
+
+	cmd.Stdout = buf
+	cmd.Stderr = GinkgoWriter
+
+	err := cmd.Run()
+	if err != nil {
+		GinkgoWriter.Println(buf.String())
+		return nil, err
+	}
+
+	jsonOutput := buf.Bytes()
+
+	var wrapper IstioctlJSONWrapper
+
+	err = json.Unmarshal(jsonOutput, &wrapper)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(wrapper.DynamicActiveSecrets) == 0 {
+		return nil, fmt.Errorf("fatal: got no secrets from istioctl")
+	}
+
+	for _, secret := range wrapper.DynamicActiveSecrets {
+		if secret.Name != "default" {
+			continue
+		}
+
+		tlsCertificateMap, err := diveMap(secret.Secret, "tlsCertificate")
+		if err != nil {
+			return nil, err
+		}
+
+		certificateChainMap, err := diveMap(tlsCertificateMap, "certificateChain")
+		if err != nil {
+			return nil, err
+		}
+
+		base64Raw, ok := certificateChainMap["inlineBytes"]
+		if !ok {
+			return nil, fmt.Errorf("failed to find inlineBytes key in certificateChain part of secret")
+		}
+
+		base64String, ok := base64Raw.(string)
+		if !ok {
+			return nil, fmt.Errorf("failed to convert inlineBytes to a string")
+		}
+
+		chainBytes, err := base64.StdEncoding.DecodeString(base64String)
+		if err != nil {
+			return nil, err
+		}
+
+		return cmutil.DecodeX509CertificateSetBytes(chainBytes)
+	}
+
+	return nil, fmt.Errorf("couldn't find cert secret for %s/%s", namespaceName, podName)
+}


### PR DESCRIPTION
To use "true" runtime configuration (with no issuerRef defined in the Helm values) it's necessary to have a solution for dynamically generating the istiod cert, which is usually created via a Certificate resource defined in the chart.

This PR adds the ability to dynamically generate the cert. Part of that requires the need to be able to signal that the runtime configured issuerRef has changed to trigger re-issuance.

The dynamic istiod cert is managed through a new controller, and also added is a runnable which watches for issuerRef changes. The notification system for the issuerRef changes is also used to allow the istio serving cert to be provisioned only when an issuer is available.

## Testing

On a local checkout of the branch run:

```console
$ make e2e-create-cert-manager-istio-resources
# creates a cluster, installs cert-manager, creates an issuer

$ k apply -f test/e2e/runtimeconfig-manifests/issuers/issuer.yaml
# creates another issuer (runtimeconfig-ca-issuer), which we can use later

$ cat > _bin/values.yaml <<EOF
image:
  repository: cert-manager.local/cert-manager-istio-csr

app:
  logLevel: 5
  logFormat: json
  runtimeIssuanceConfigMap: runtime-config-map
  certmanager:
    issuer:
      name: ""
      kind: ""
      group: ""
  tls:
    istiodCertificateEnable: "dynamic"
  istio:
    revisions: ["default", "abc"]
EOF

$ make oci-load-manager && make INSTALL_OPTIONS="--values _bin/values.yaml" install

#  this should hang because no issuer was configured in the chart values and there's no runtime configuration yet

# in a separate terminal:
$ kubectl create configmap runtime-config-map -n cert-manager \
        --from-literal=issuer-name=istio-ca \
        --from-literal=issuer-kind=Issuer \
        --from-literal=issuer-group=cert-manager.io

# the install of istio-csr should continue now
# there should be a istiod-tls secret in the istio-system namespace

# Change the runtime config map to point at the other issuer we created
$ k edit -n cert-manager cm runtime-config-map
# Change issuer to runtimeconfig-ca-issuer

# istiod-tls should be reissued
```