### PR TITLE
Add retries for issuing initial serving cert

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-logr/logr v1.4.2
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+	github.com/lestrrat-go/backoff/v2 v2.0.8
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	github.com/prometheus/client_golang v1.19.1
@@ -80,7 +81,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/lestrrat-go/backoff/v2 v2.0.8 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.2 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
 	github.com/lestrrat-go/iter v1.0.2 // indirect

--- a/pkg/certmanager/certmanager.go
+++ b/pkg/certmanager/certmanager.go
@@ -82,12 +82,11 @@ type IssuerChangeNotifier interface {
 	// as updates happen.
 	SubscribeIssuerChange() <-chan *cmmeta.ObjectReference
 
-	// MustWaitForIssuer returns true if there's no "default" issuerRef available
-	// (i.e. no static issuerRef was configured at startup)
+	// HasIssuerConfig returns true if there's a configured active issuer ref.
+	// (i.e. a static issuerRef was configured at startup / runtime issuance config has been successfully acquired)
 	// If this function returns true, InitialIssuer will always return nil and
-	// subscribers must wait for runtime configuration before trying to issue
-	// certificates
-	MustWaitForIssuer() bool
+	// subscribers must wait for runtime configuration before trying to issue certificates
+	HasIssuerConfig() bool
 
 	// InitialIssuer returns the "static" issuer which was configured at startup. Will
 	// always return nil if no such issuer exists.
@@ -475,9 +474,8 @@ func (m *manager) SubscribeIssuerChange() <-chan *cmmeta.ObjectReference {
 	return ch
 }
 
-func (m *manager) MustWaitForIssuer() bool {
-	// if no originalIssuerRef was configured, must wait for runtime configuration
-	return m.originalIssuerRef == nil
+func (m *manager) HasIssuerConfig() bool {
+	return m.activeIssuerRef != nil
 }
 
 func (m *manager) InitialIssuer() *cmmeta.ObjectReference {


### PR DESCRIPTION
This enables istio-csr to be installed concurrently with cert-manager and to continue trying to operate until the initial serving cert is available