### PR TITLE
Add security context to istio-csr deployment

### DIFF
--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -428,21 +428,26 @@ resources:
     cpu: 100m
     memory: 128Mi
 ```
-#### **seccompProfile** ~ `object`
+#### **securityContext.allowPrivilegeEscalation** ~ `bool`
 > Default value:
 > ```yaml
-> {}
+> false
 > ```
-
-Kubernetes security context seccomp profile  
-ref: https://kubernetes.io/docs/tutorials/security/seccomp/  
-  
-For example:
-
-```yaml
-seccompProfile:
-  type: RuntimeDefault
-```
+#### **securityContext.readOnlyRootFilesystem** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+#### **securityContext.runAsNonRoot** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+#### **securityContext.capabilities.drop[0]** ~ `string`
+> Default value:
+> ```yaml
+> ALL
+> ```
 #### **affinity** ~ `object`
 > Default value:
 > ```yaml

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -428,6 +428,21 @@ resources:
     cpu: 100m
     memory: 128Mi
 ```
+#### **seccompProfile** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Kubernetes security context seccomp profile  
+ref: https://kubernetes.io/docs/tutorials/security/seccomp/  
+  
+For example:
+
+```yaml
+seccompProfile:
+  type: RuntimeDefault
+```
 #### **affinity** ~ `object`
 > Default value:
 > ```yaml

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -121,16 +121,7 @@ spec:
           {{- toYaml .Values.resources | nindent 12 }}
 
         securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          capabilities:
-            drop:
-            - ALL
-          {{- if .Values.seccompProfile }}
-          seccompProfile:
-            {{ toYaml .Values.seccompProfile | indent 14 }}
-          {{- end }}
+          {{- toYaml .Values.securityContext | nindent 12 }}
 
       {{- if .Values.volumes }}
       volumes:

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -120,6 +120,18 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
 
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+          {{- if .Values.seccompProfile }}
+          seccompProfile:
+            {{ toYaml .Values.seccompProfile | indent 14 }}
+          {{- end }}
+
       {{- if .Values.volumes }}
       volumes:
 {{ toYaml .Values.volumes | indent 6 }}

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -33,6 +33,9 @@
         "resources": {
           "$ref": "#/$defs/helm-values.resources"
         },
+        "seccompProfile": {
+          "$ref": "#/$defs/helm-values.seccompProfile"
+        },
         "service": {
           "$ref": "#/$defs/helm-values.service"
         },
@@ -581,6 +584,11 @@
     "helm-values.resources": {
       "default": {},
       "description": "Kubernetes pod resources\nref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\n\nFor example:\nresources:\n  limits:\n    cpu: 100m\n    memory: 128Mi\n  requests:\n    cpu: 100m\n    memory: 128Mi",
+      "type": "object"
+    },
+    "helm-values.seccompProfile": {
+      "default": {},
+      "description": "Kubernetes security context seccomp profile\nref: https://kubernetes.io/docs/tutorials/security/seccomp/\n\nFor example:\nseccompProfile:\n  type: RuntimeDefault",
       "type": "object"
     },
     "helm-values.service": {

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -33,8 +33,8 @@
         "resources": {
           "$ref": "#/$defs/helm-values.resources"
         },
-        "seccompProfile": {
-          "$ref": "#/$defs/helm-values.seccompProfile"
+        "securityContext": {
+          "$ref": "#/$defs/helm-values.securityContext"
         },
         "service": {
           "$ref": "#/$defs/helm-values.service"
@@ -586,10 +586,54 @@
       "description": "Kubernetes pod resources\nref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\n\nFor example:\nresources:\n  limits:\n    cpu: 100m\n    memory: 128Mi\n  requests:\n    cpu: 100m\n    memory: 128Mi",
       "type": "object"
     },
-    "helm-values.seccompProfile": {
-      "default": {},
-      "description": "Kubernetes security context seccomp profile\nref: https://kubernetes.io/docs/tutorials/security/seccomp/\n\nFor example:\nseccompProfile:\n  type: RuntimeDefault",
+    "helm-values.securityContext": {
+      "additionalProperties": false,
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "$ref": "#/$defs/helm-values.securityContext.allowPrivilegeEscalation"
+        },
+        "capabilities": {
+          "$ref": "#/$defs/helm-values.securityContext.capabilities"
+        },
+        "readOnlyRootFilesystem": {
+          "$ref": "#/$defs/helm-values.securityContext.readOnlyRootFilesystem"
+        },
+        "runAsNonRoot": {
+          "$ref": "#/$defs/helm-values.securityContext.runAsNonRoot"
+        }
+      },
       "type": "object"
+    },
+    "helm-values.securityContext.allowPrivilegeEscalation": {
+      "default": false,
+      "type": "boolean"
+    },
+    "helm-values.securityContext.capabilities": {
+      "additionalProperties": false,
+      "properties": {
+        "drop": {
+          "$ref": "#/$defs/helm-values.securityContext.capabilities.drop"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.securityContext.capabilities.drop": {
+      "items": {
+        "$ref": "#/$defs/helm-values.securityContext.capabilities.drop[0]"
+      },
+      "type": "array"
+    },
+    "helm-values.securityContext.capabilities.drop[0]": {
+      "default": "ALL",
+      "type": "string"
+    },
+    "helm-values.securityContext.readOnlyRootFilesystem": {
+      "default": true,
+      "type": "boolean"
+    },
+    "helm-values.securityContext.runAsNonRoot": {
+      "default": true,
+      "type": "boolean"
     },
     "helm-values.service": {
       "additionalProperties": false,

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -243,6 +243,14 @@ volumeMounts: []
 #      memory: 128Mi
 resources: {}
 
+# Kubernetes security context seccomp profile
+# ref: https://kubernetes.io/docs/tutorials/security/seccomp/
+#
+# For example:
+#   seccompProfile:
+#     type: RuntimeDefault
+seccompProfile: {}
+
 # Expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
 #
 # For example:

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -243,13 +243,17 @@ volumeMounts: []
 #      memory: 128Mi
 resources: {}
 
-# Kubernetes security context seccomp profile
-# ref: https://kubernetes.io/docs/tutorials/security/seccomp/
+# Kubernetes security context
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 #
-# For example:
-#   seccompProfile:
-#     type: RuntimeDefault
-seccompProfile: {}
+# See the default values for an example.
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  capabilities:
+    drop:
+    - ALL
 
 # Expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
 #


### PR DESCRIPTION
## Description
* The default security context may be too permissive compared to what a cluster operator requires; configure it to be as restrictive as possible.
* Allow configuring the seccompprofile in case more restrictive custom policies need to be applied
* Fixes #367