### PR TITLE
Feat/add labels and annotations

### DIFF
--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -383,28 +383,28 @@ to avoid overloading the server.
 > {}
 > ```
 
-Optional labels for deployment
+Optional extra labels for deployment.
 #### **deploymentAnnotations** ~ `object`
 > Default value:
 > ```yaml
 > {}
 > ```
 
-Optional annotations for deployment
+Optional extra annotations for deployment.
 #### **podLabels** ~ `object`
 > Default value:
 > ```yaml
 > {}
 > ```
 
-Optional labels for pod
+Optional extra labels for pod.
 #### **podAnnotations** ~ `object`
 > Default value:
 > ```yaml
 > {}
 > ```
 
-Optional annotations for pod
+Optional extra annotations for pod.
 #### **volumes** ~ `array`
 > Default value:
 > ```yaml

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -377,6 +377,34 @@ Example: maistra.io/member-of=istio-system
 Allows you to disable the default Kubernetes client rate limiter if istio-csr is exceeding the default QPS (5) and Burst (10) limits. For example in large clusters with many Istio workloads, restarting the Pods may cause istio-csr to send bursts Kubernetes API requests that exceed the limits of the default Kubernetes client rate limiter and istio-csr will become slow to issue certificates for your workloads. Only disable client rate limiting if the Kubernetes API server supports  
 [API Priority and Fairness](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/),  
 to avoid overloading the server.
+#### **deploymentLabels** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Optional labels for deployment
+#### **deploymentAnnotations** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Optional annotations for deployment
+#### **podLabels** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Optional labels for pod
+#### **podAnnotations** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Optional annotations for pod
 #### **volumes** ~ `array`
 > Default value:
 > ```yaml

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cert-manager-istio-csr.labels" . | nindent 4 }}
+    {{- with .Values.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -15,6 +22,13 @@ spec:
       labels:
         app: {{ include "cert-manager-istio-csr.name" . }}
         {{- include "cert-manager-istio-csr.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -50,6 +50,18 @@
         },
         "volumes": {
           "$ref": "#/$defs/helm-values.volumes"
+        },
+        "deploymentAnnotations": {
+          "$ref": "#/$defs/helm-values.deploymentAnnotations"
+        },
+        "deploymentLabels": {
+          "$ref": "#/$defs/helm-values.deploymentLabels"
+        },
+        "podAnnotations": {
+          "$ref": "#/$defs/helm-values.podAnnotations"
+        },
+        "podLabels": {
+          "$ref": "#/$defs/helm-values.podLabels"
         }
       },
       "type": "object"
@@ -687,6 +699,26 @@
       "description": "Optional extra volumes. Useful for mounting custom root CAs\n\nFor example:\nvolumes:\n- name: root-ca\n  secret:\n    secretName: root-cert",
       "items": {},
       "type": "array"
+    },
+    "helm-values.deploymentLabels": {
+      "default": {},
+      "description": "Optional labels for deployment",
+      "type": "object"
+    },
+    "helm-values.deploymentAnnotations": {
+      "default": {},
+      "description": "Optional annotations for deployment",
+      "type": "object"
+    },
+    "helm-values.podLabels": {
+      "default": {},
+      "description": "Optional labels for pod",
+      "type": "object"
+    },
+    "helm-values.podAnnotations": {
+      "default": {},
+      "description": "Optional annotations for pod",
+      "type": "object"
     }
   },
   "$ref": "#/$defs/helm-values",

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -702,22 +702,22 @@
     },
     "helm-values.deploymentLabels": {
       "default": {},
-      "description": "Optional labels for deployment",
+      "description": "Optional extra labels for deployment.",
       "type": "object"
     },
     "helm-values.deploymentAnnotations": {
       "default": {},
-      "description": "Optional annotations for deployment",
+      "description": "Optional extra annotations for deployment.",
       "type": "object"
     },
     "helm-values.podLabels": {
       "default": {},
-      "description": "Optional labels for pod",
+      "description": "Optional extra labels for pod.",
       "type": "object"
     },
     "helm-values.podAnnotations": {
       "default": {},
-      "description": "Optional annotations for pod",
+      "description": "Optional extra annotations for pod.",
       "type": "object"
     }
   },

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -127,7 +127,7 @@ app:
     # presented to istio-agents. istio-agents must route to istio-csr using one
     # of these DNS names.
     certificateDNSNames:
-    - cert-manager-istio-csr.cert-manager.svc
+      - cert-manager-istio-csr.cert-manager.svc
     # Requested duration of gRPC serving certificate. Will be automatically
     # renewed.
     # Based on NIST 800-204A recommendations (SM-DR13).
@@ -213,6 +213,18 @@ app:
     # to avoid overloading the server.
     disableKubernetesClientRateLimiter: false
 
+# Optional labels for deployment
+deploymentLabels: {}
+
+# Optional annotations for deployment
+deploymentAnnotations: {}
+
+# Optional labels for pod
+podLabels: {}
+
+# Optional annotations for pod
+podAnnotations: {}
+
 # Optional extra volumes. Useful for mounting custom root CAs
 #
 # For example:
@@ -253,7 +265,7 @@ securityContext:
   runAsNonRoot: true
   capabilities:
     drop:
-    - ALL
+      - ALL
 
 # Expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
 #

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -213,16 +213,16 @@ app:
     # to avoid overloading the server.
     disableKubernetesClientRateLimiter: false
 
-# Optional labels for deployment
+# Optional extra labels for deployment.
 deploymentLabels: {}
 
-# Optional annotations for deployment
+# Optional extra annotations for deployment.
 deploymentAnnotations: {}
 
-# Optional labels for pod
+# Optional extra labels for pod.
 podLabels: {}
 
-# Optional annotations for pod
+# Optional extra annotations for pod.
 podAnnotations: {}
 
 # Optional extra volumes. Useful for mounting custom root CAs

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -127,7 +127,7 @@ app:
     # presented to istio-agents. istio-agents must route to istio-csr using one
     # of these DNS names.
     certificateDNSNames:
-      - cert-manager-istio-csr.cert-manager.svc
+    - cert-manager-istio-csr.cert-manager.svc
     # Requested duration of gRPC serving certificate. Will be automatically
     # renewed.
     # Based on NIST 800-204A recommendations (SM-DR13).
@@ -265,7 +265,7 @@ securityContext:
   runAsNonRoot: true
   capabilities:
     drop:
-      - ALL
+    - ALL
 
 # Expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
 #


### PR DESCRIPTION
I am using ArgoCD to deploy the various manifests to bootstrap my cluster. As part of the deployments I am using [sync-wave](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/#how-do-i-configure-waves) annotation. 

Added the support to add labels and annotations to the deployment and pod. 

Addresses: 
- Issues: 
  - #211 
- Stale PRs:
  - https://github.com/cert-manager/istio-csr/pull/270
  - https://github.com/cert-manager/istio-csr/pull/202