### PR TITLE
added labels and annotations to deployment and pod

### DIFF
--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -423,6 +423,34 @@ Example: maistra.io/member-of=istio-system
 Allows you to disable the default Kubernetes client rate limiter if istio-csr is exceeding the default QPS (5) and Burst (10) limits. For example in large clusters with many Istio workloads, restarting the Pods may cause istio-csr to send bursts Kubernetes API requests that exceed the limits of the default Kubernetes client rate limiter and istio-csr will become slow to issue certificates for your workloads. Only disable client rate limiting if the Kubernetes API server supports  
 [API Priority and Fairness](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/),  
 to avoid overloading the server.
+#### **deploymentLabels** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Optional extra labels for deployment.
+#### **deploymentAnnotations** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Optional extra annotations for deployment.
+#### **podLabels** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Optional extra labels for pod.
+#### **podAnnotations** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Optional extra annotations for pod.
 #### **volumes** ~ `array`
 > Default value:
 > ```yaml

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cert-manager-istio-csr.labels" . | nindent 4 }}
+    {{- with .Values.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -15,6 +22,13 @@ spec:
       labels:
         app: {{ include "cert-manager-istio-csr.name" . }}
         {{- include "cert-manager-istio-csr.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -53,6 +53,18 @@
         },
         "volumes": {
           "$ref": "#/$defs/helm-values.volumes"
+        },
+        "deploymentAnnotations": {
+          "$ref": "#/$defs/helm-values.deploymentAnnotations"
+        },
+        "deploymentLabels": {
+          "$ref": "#/$defs/helm-values.deploymentLabels"
+        },
+        "podAnnotations": {
+          "$ref": "#/$defs/helm-values.podAnnotations"
+        },
+        "podLabels": {
+          "$ref": "#/$defs/helm-values.podLabels"
         }
       },
       "type": "object"
@@ -770,6 +782,26 @@
       "description": "Optional extra volumes. Useful for mounting custom root CAs\n\nFor example:\nvolumes:\n- name: root-ca\n  secret:\n    secretName: root-cert",
       "items": {},
       "type": "array"
+    },
+    "helm-values.deploymentLabels": {
+      "default": {},
+      "description": "Optional extra labels for deployment.",
+      "type": "object"
+    },
+    "helm-values.deploymentAnnotations": {
+      "default": {},
+      "description": "Optional extra annotations for deployment.",
+      "type": "object"
+    },
+    "helm-values.podLabels": {
+      "default": {},
+      "description": "Optional extra labels for pod.",
+      "type": "object"
+    },
+    "helm-values.podAnnotations": {
+      "default": {},
+      "description": "Optional extra annotations for pod.",
+      "type": "object"
     }
   },
   "$ref": "#/$defs/helm-values",

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -12,6 +12,12 @@
         "commonLabels": {
           "$ref": "#/$defs/helm-values.commonLabels"
         },
+        "deploymentAnnotations": {
+          "$ref": "#/$defs/helm-values.deploymentAnnotations"
+        },
+        "deploymentLabels": {
+          "$ref": "#/$defs/helm-values.deploymentLabels"
+        },
         "extraObjects": {
           "$ref": "#/$defs/helm-values.extraObjects"
         },
@@ -29,6 +35,12 @@
         },
         "nodeSelector": {
           "$ref": "#/$defs/helm-values.nodeSelector"
+        },
+        "podAnnotations": {
+          "$ref": "#/$defs/helm-values.podAnnotations"
+        },
+        "podLabels": {
+          "$ref": "#/$defs/helm-values.podLabels"
         },
         "replicaCount": {
           "$ref": "#/$defs/helm-values.replicaCount"
@@ -53,18 +65,6 @@
         },
         "volumes": {
           "$ref": "#/$defs/helm-values.volumes"
-        },
-        "deploymentAnnotations": {
-          "$ref": "#/$defs/helm-values.deploymentAnnotations"
-        },
-        "deploymentLabels": {
-          "$ref": "#/$defs/helm-values.deploymentLabels"
-        },
-        "podAnnotations": {
-          "$ref": "#/$defs/helm-values.podAnnotations"
-        },
-        "podLabels": {
-          "$ref": "#/$defs/helm-values.podLabels"
         }
       },
       "type": "object"
@@ -602,6 +602,16 @@
       "description": "Labels to apply to all resources",
       "type": "object"
     },
+    "helm-values.deploymentAnnotations": {
+      "default": {},
+      "description": "Optional extra annotations for deployment.",
+      "type": "object"
+    },
+    "helm-values.deploymentLabels": {
+      "default": {},
+      "description": "Optional extra labels for deployment.",
+      "type": "object"
+    },
     "helm-values.extraObjects": {
       "default": [],
       "description": "Create resources alongside installing istio-csr, via Helm values. Can accept an array of YAML-formatted resources. Each array entry can include multiple YAML documents, separated by '---'\n\nFor example:\nextraObjects:\n  - |\n    apiVersion: v1\n    kind: ConfigMap\n    metadata:\n      name: '{{ template \"cert-manager-istio-csr.fullname\" . }}-extra-configmap'",
@@ -669,6 +679,16 @@
         "kubernetes.io/os": "linux"
       },
       "description": "Kubernetes node selector: node labels for pod assignment.",
+      "type": "object"
+    },
+    "helm-values.podAnnotations": {
+      "default": {},
+      "description": "Optional extra annotations for pod.",
+      "type": "object"
+    },
+    "helm-values.podLabels": {
+      "default": {},
+      "description": "Optional extra labels for pod.",
       "type": "object"
     },
     "helm-values.replicaCount": {
@@ -782,26 +802,6 @@
       "description": "Optional extra volumes. Useful for mounting custom root CAs\n\nFor example:\nvolumes:\n- name: root-ca\n  secret:\n    secretName: root-cert",
       "items": {},
       "type": "array"
-    },
-    "helm-values.deploymentLabels": {
-      "default": {},
-      "description": "Optional extra labels for deployment.",
-      "type": "object"
-    },
-    "helm-values.deploymentAnnotations": {
-      "default": {},
-      "description": "Optional extra annotations for deployment.",
-      "type": "object"
-    },
-    "helm-values.podLabels": {
-      "default": {},
-      "description": "Optional extra labels for pod.",
-      "type": "object"
-    },
-    "helm-values.podAnnotations": {
-      "default": {},
-      "description": "Optional extra annotations for pod.",
-      "type": "object"
     }
   },
   "$ref": "#/$defs/helm-values",

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -251,6 +251,18 @@ app:
     # to avoid overloading the server.
     disableKubernetesClientRateLimiter: false
 
+# Optional extra labels for deployment.
+deploymentLabels: {}
+
+# Optional extra annotations for deployment.
+deploymentAnnotations: {}
+
+# Optional extra labels for pod.
+podLabels: {}
+
+# Optional extra annotations for pod.
+podAnnotations: {}
+
 # Optional extra volumes. Useful for mounting custom root CAs
 #
 # For example:


### PR DESCRIPTION
I am using ArgoCD to deploy the various manifests to bootstrap my cluster. As part of the deployments I am using [sync-wave](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/#how-do-i-configure-waves) annotation. 

Added the support to add labels and annotations to the deployment and pod. 

Addresses: 
- Issues: 
  - #211 
- Stale PRs:
  - https://github.com/cert-manager/istio-csr/pull/270
  - https://github.com/cert-manager/istio-csr/pull/202