### PR TITLE
feat: add ability to specify extra objects to apply along with the chart

### DIFF
--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -548,5 +548,23 @@ Kubernetes node selector: node labels for pod assignment.
 > ```
 
 Labels to apply to all resources
+#### **extraObjects** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+Create resources alongside installing istio-csr, via Helm values. Can accept an array of YAML-formatted resources. Each array entry can include multiple YAML documents, separated by '---'  
+  
+For example:
+
+```yaml
+extraObjects:
+  - |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: '{{ template "cert-manager-istio-csr.fullname" . }}-extra-configmap'
+```
 
 <!-- /AUTO-GENERATED -->

--- a/deploy/charts/istio-csr/templates/extra-objects.yaml
+++ b/deploy/charts/istio-csr/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl . $ }}
+{{ end }}

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -12,6 +12,9 @@
         "commonLabels": {
           "$ref": "#/$defs/helm-values.commonLabels"
         },
+        "extraObjects": {
+          "$ref": "#/$defs/helm-values.extraObjects"
+        },
         "global": {
           "$ref": "#/$defs/helm-values.global"
         },
@@ -570,6 +573,12 @@
       "default": {},
       "description": "Labels to apply to all resources",
       "type": "object"
+    },
+    "helm-values.extraObjects": {
+      "default": [],
+      "description": "Create resources alongside installing istio-csr, via Helm values. Can accept an array of YAML-formatted resources. Each array entry can include multiple YAML documents, separated by '---'\n\nFor example:\nextraObjects:\n  - |\n    apiVersion: v1\n    kind: ConfigMap\n    metadata:\n      name: '{{ template \"cert-manager-istio-csr.fullname\" . }}-extra-configmap'",
+      "items": {},
+      "type": "array"
     },
     "helm-values.global": {
       "description": "Global values shared across all (sub)charts"

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -325,3 +325,15 @@ nodeSelector:
 
 # Labels to apply to all resources
 commonLabels: {}
+
+# Create resources alongside installing istio-csr, via Helm values. Can accept an array of YAML-formatted
+# resources. Each array entry can include multiple YAML documents, separated by '---'
+#
+# For example:
+# extraObjects:
+#   - |
+#     apiVersion: v1
+#     kind: ConfigMap
+#     metadata:
+#       name: '{{ template "cert-manager-istio-csr.fullname" . }}-extra-configmap'
+extraObjects: []


### PR DESCRIPTION
This is useful because istio-csr depends on an external issuer to function. The ability to configure that issuer when deploying is desirable.