### PR TITLE
feat: allow "runtime-only" configuration without default issuer

### DIFF
--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -263,6 +263,9 @@ func (o *Options) addCertManagerFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&o.CertManager.Namespace,
 		"certificate-namespace", "c", "istio-system",
 		"Namespace to request certificates.")
+	fs.BoolVarP(&o.CertManager.DefaultIssuerEnabled,
+		"issuer-enabled", "e", true,
+		"Enable the default issuer, the application will not become ready until this issuer is available.")
 	fs.StringVarP(&o.CertManager.IssuerRef.Name,
 		"issuer-name", "u", "istio-ca",
 		"Name of the issuer to sign istio workload certificates.")

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -229,6 +229,17 @@ additionalAnnotations:
   - name: custom.cert-manager.io/policy-name
     value: istio-csr
 ```
+#### **app.certmanager.issuer.enabled** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Enable the default issuer, this is the issuer used when no runtime configuration is provided.  
+  
+When enabled the istio-csr Pod will not be "Ready" until the issuer has been used to issue the istio-csr GRPC certificate.  
+  
+For istio-csr to function either this or runtime configuration must be enabled.
 #### **app.certmanager.issuer.name** ~ `string`
 > Default value:
 > ```yaml

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -59,6 +59,7 @@ spec:
 
             # cert-manager
           - "--certificate-namespace={{.Values.app.certmanager.namespace}}"
+          - "--issuer-enabled={{.Values.app.certmanager.issuer.enabled}}"
           - "--issuer-name={{.Values.app.certmanager.issuer.name}}"
           - "--issuer-kind={{.Values.app.certmanager.issuer.kind}}"
           - "--issuer-group={{.Values.app.certmanager.issuer.group}}"

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -128,6 +128,9 @@
     "helm-values.app.certmanager.issuer": {
       "additionalProperties": false,
       "properties": {
+        "enabled": {
+          "$ref": "#/$defs/helm-values.app.certmanager.issuer.enabled"
+        },
         "group": {
           "$ref": "#/$defs/helm-values.app.certmanager.issuer.group"
         },
@@ -139,6 +142,11 @@
         }
       },
       "type": "object"
+    },
+    "helm-values.app.certmanager.issuer.enabled": {
+      "default": true,
+      "description": "Enable the default issuer, this is the issuer used when no runtime configuration is provided.\n\nWhen enabled the istio-csr Pod will not be \"Ready\" until the issuer has been used to issue the istio-csr GRPC certificate.\n\nFor istio-csr to function either this or runtime configuration must be enabled.",
+      "type": "boolean"
     },
     "helm-values.app.certmanager.issuer.group": {
       "default": "cert-manager.io",

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -133,6 +133,15 @@ app:
     #      value: istio-csr
     additionalAnnotations: []
     issuer:
+      # Enable the default issuer, this is the issuer used when no runtime 
+      # configuration is provided.
+      #
+      # When enabled the istio-csr Pod will not be "Ready" until the issuer
+      # has been used to issue the istio-csr GRPC certificate.
+      #
+      # For istio-csr to function either this or runtime configuration must be
+      # enabled.
+      enabled: true
       # Issuer name set on created CertificateRequests for both istio-csr's
       # serving certificate and incoming gRPC CSRs.
       name: istio-ca

--- a/make/test-e2e.mk
+++ b/make/test-e2e.mk
@@ -128,6 +128,7 @@ test-e2e: test-e2e-deps-sidecars | kind-cluster $(NEEDS_GINKGO) $(NEEDS_KUBECTL)
 test-e2e-pure-runtime-deps: INSTALL_OPTIONS :=
 test-e2e-pure-runtime-deps: INSTALL_OPTIONS += --set image.repository=$(oci_manager_image_name_development)
 test-e2e-pure-runtime-deps: INSTALL_OPTIONS += --set app.runtimeConfiguration.name=$(E2E_RUNTIME_CONFIG_MAP_NAME)
+test-e2e-pure-runtime-deps: INSTALL_OPTIONS += --set app.certmanager.issuer.enabled=false
 test-e2e-pure-runtime-deps: INSTALL_OPTIONS += -f ./make/config/istio-csr-pure-runtime-values.yaml
 test-e2e-pure-runtime-deps: e2e-setup-cert-manager
 test-e2e-pure-runtime-deps: e2e-create-cert-manager-istio-resources

--- a/pkg/controller/configmap.go
+++ b/pkg/controller/configmap.go
@@ -172,7 +172,12 @@ func (c *configmap) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resul
 		return ctrl.Result{}, nil
 	}
 
-	rootCAsPEM := string(c.tls.RootCAs().PEM)
+	rootCAs := c.tls.RootCAs(ctx)
+	if rootCAs == nil {
+		return ctrl.Result{}, fmt.Errorf("could not get root certificates: %w", ctx.Err())
+	}
+
+	rootCAsPEM := string(rootCAs.PEM)
 
 	// Check ConfigMap exists, and has the correct data.
 	var configMap corev1.ConfigMap

--- a/pkg/istiodcert/worker.go
+++ b/pkg/istiodcert/worker.go
@@ -57,7 +57,7 @@ type DynamicIstiodCertProvisioner struct {
 
 	issuerRefMutex sync.Mutex
 
-	issuerChangeChan <-chan *cmmeta.ObjectReference
+	issuerChangeSubscription *certmanager.IssuerChangeSubscription
 
 	reconcileChan chan event.GenericEvent
 
@@ -83,7 +83,7 @@ func New(log logr.Logger, restConfig *rest.Config, opts Options, issuerChangeNot
 
 		issuerRefMutex: sync.Mutex{},
 
-		issuerChangeChan: issuerChangeNotifier.SubscribeIssuerChange(),
+		issuerChangeSubscription: issuerChangeNotifier.SubscribeIssuerChange(),
 
 		reconcileChan: make(chan event.GenericEvent),
 
@@ -101,7 +101,7 @@ func (dicp *DynamicIstiodCertProvisioner) Start(ctx context.Context) error {
 			dicp.log.Info("Received context cancellation, shutting down dynamic istiod cert provisioner")
 			return nil
 
-		case newIssuer := <-dicp.issuerChangeChan:
+		case newIssuer := <-dicp.issuerChangeSubscription.C:
 			dicp.handleNewIssuer(newIssuer)
 		}
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -689,7 +689,7 @@ func Test_parseCertificateBundle(t *testing.T) {
 				tls: tlsfake.New().WithRootCAs(rootCAsPEM, rootCAsPool),
 			}
 
-			chain, err := s.parseCertificateBundle(test.bundle)
+			chain, err := s.parseCertificateBundle(context.Background(), test.bundle)
 			assert.Equalf(t, test.expErr, err != nil, "%v", err)
 			assert.Equal(t, test.expChain, chain)
 		})

--- a/pkg/tls/fake/fake.go
+++ b/pkg/tls/fake/fake.go
@@ -32,7 +32,7 @@ var _ cmtls.Interface = &FakeTLS{}
 // FakeTLS is a fake implementation of tls.Interface that can be used for testing.
 type FakeTLS struct {
 	funcTrustDomain           func() string
-	funcRootCAs               func() rootca.RootCAs
+	funcRootCAs               func(ctx context.Context) *rootca.RootCAs
 	funcConfig                func(ctx context.Context) (*tls.Config, error)
 	funcSubscribeRootCAsEvent func() <-chan event.GenericEvent
 }
@@ -40,14 +40,14 @@ type FakeTLS struct {
 func New() *FakeTLS {
 	return &FakeTLS{
 		funcTrustDomain:           func() string { return "" },
-		funcRootCAs:               func() rootca.RootCAs { return rootca.RootCAs{} },
+		funcRootCAs:               func(ctx context.Context) *rootca.RootCAs { return &rootca.RootCAs{} },
 		funcConfig:                func(_ context.Context) (*tls.Config, error) { return nil, nil },
 		funcSubscribeRootCAsEvent: func() <-chan event.GenericEvent { return make(chan event.GenericEvent) },
 	}
 }
 
 func (f *FakeTLS) WithRootCAs(rootCAsPEM []byte, rootCAsPool *x509.CertPool) *FakeTLS {
-	f.funcRootCAs = func() rootca.RootCAs { return rootca.RootCAs{PEM: rootCAsPEM, CertPool: rootCAsPool} }
+	f.funcRootCAs = func(context.Context) *rootca.RootCAs { return &rootca.RootCAs{PEM: rootCAsPEM, CertPool: rootCAsPool} }
 	return f
 }
 
@@ -55,8 +55,8 @@ func (f *FakeTLS) TrustDomain() string {
 	return f.funcTrustDomain()
 }
 
-func (f *FakeTLS) RootCAs() rootca.RootCAs {
-	return f.funcRootCAs()
+func (f *FakeTLS) RootCAs(ctx context.Context) *rootca.RootCAs {
+	return f.funcRootCAs(ctx)
 }
 
 func (f *FakeTLS) Config(ctx context.Context) (*tls.Config, error) {


### PR DESCRIPTION
## Changes

### Helm

- Added `app.certmanager.issuer.enabled` to disable "default" non runtime issuer.

### app.go

- Wrapped the health checks to only run when issuer config is available. This means that we still go "not ready" if invalid issuer config is provided or the runtime config obtained is invalid. 

### options.go

- Added `--issuer-enabled` flag to disable "default" non runtime issuer. By setting this to false you can start istio-csr up and have it idle waiting for runtime config (while being ready).

### certmanager.go

- Updated the runtime config watcher to prune subscriptions that are not in use. Functions like `WaitForIssuerConfig` only need a single channel event then stopped monitoring it. The addition of the ability to "close" the subscription means these functions can "unsubscribe".

- Moved `WaitForIssuerConfig` into the manager, it makes sense in my mind for it to be there so multiple things can call it if needed.

### configmap.go / tls.go

- The original implementation of `tls.Interface.RootCAs` was blocking, this meant that if you had no "default" issuer config and the runtime config was not yet configured then the configmap controller Reconcile would block forever and delay graceful shutdown. The new implementation of `RootCAs` accepts a context so the controller can shut down gracefully. 

