### PR TITLE
Propagate annotations

### DIFF
--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -91,7 +91,7 @@ spec:
 
           # server authenticators
           - "--enable-client-cert-authenticator={{.Values.app.server.authenticators.enableClientCert}}"
-          
+
           # trusted node accounts
           {{- if .Values.app.server.caTrustedNodeAccounts }}
           - "--ca-trusted-node-accounts={{.Values.app.server.caTrustedNodeAccounts }}"

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -115,6 +115,13 @@ spec:
           - "--istiod-cert-key-algorithm={{ default .Values.app.server.serving.signatureAlgorithm .Values.app.tls.istiodPrivateKeyAlgorithm }}"
           - "--istiod-cert-key-size={{ .Values.app.tls.istiodPrivateKeySize }}"
           - "--istiod-cert-additional-dns-names={{ join "," .Values.app.tls.istiodAdditionalDNSNames }}"
+          {{- if .Values.app.certmanager.additionalAnnotations }}
+          {{- $annotationList := list }}
+          {{- range $annotation := .Values.app.certmanager.additionalAnnotations }}
+          {{ $annotationList = append $annotationList (printf "%s=%s" $annotation.name $annotation.value) }}
+          {{- end }}
+          - "--istiod-cert-additional-annotations={{ join "," $annotationList }}"
+          {{- end }}
           - "--istiod-cert-istio-revisions={{ join "," .Values.app.istio.revisions }}"
         {{- if .Values.volumeMounts }}
         volumeMounts:

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -94,7 +94,7 @@ app:
     # runtime configuration of an issuer to use.
     #
     # If create is set to true then this name is used to create the ConfigMap,
-    # otherwise the ConfigMap must exist and the "issuer-name", "issuer-kind" 
+    # otherwise the ConfigMap must exist and the "issuer-name", "issuer-kind"
     # and "issuer-group" keys must be present in it.
     name: ""
 

--- a/make/config/istio-csr-pure-runtime-values.yaml
+++ b/make/config/istio-csr-pure-runtime-values.yaml
@@ -20,6 +20,8 @@ app:
     additionalAnnotations:
     - name: custom.cert-manager.io/policy-name
       value: istio-csr
+    - name: custom.cert-manager.io/second-annotation
+      value: some-value
     issuer:
       # Explicitly blanked out to test "pure" runtime configuration
       group: ""

--- a/pkg/istiodcert/options.go
+++ b/pkg/istiodcert/options.go
@@ -47,7 +47,8 @@ type Options struct {
 
 	CMKeyAlgorithm cmapi.PrivateKeyAlgorithm
 
-	AdditionalDNSNames []string
+	AdditionalDNSNames    []string
+	AdditionalAnnotations map[string]string
 
 	IstioRevisions []string
 }
@@ -127,6 +128,8 @@ func AddFlags(o *Options, fs *pflag.FlagSet) {
 		fmt.Sprintf("Parameter for istiod certificate key. For RSA, must be a number of bits >= %d. For ECDSA, can only be 256 or 384, corresponding to P-256 and P-384 respectively.", minRSAKeySize))
 
 	fs.StringSliceVar(&o.AdditionalDNSNames, "istiod-cert-additional-dns-names", []string{}, "Additional DNS names to use for istiod cert (if enabled). Useful if istiod needs to be accessible outside of the cluster")
+
+	fs.StringToStringVar(&o.AdditionalAnnotations, "istiod-cert-additional-annotations", map[string]string{}, "Additional annotations to add for the istiod cert (if enabled).")
 
 	fs.StringSliceVar(&o.IstioRevisions, "istiod-cert-istio-revisions", []string{}, "A list of istio revisions which should have DNS SAN entries in the dynamic istiod cert")
 }

--- a/pkg/istiodcert/worker.go
+++ b/pkg/istiodcert/worker.go
@@ -217,8 +217,9 @@ func (dicp *DynamicIstiodCertProvisioner) Reconcile(ctx context.Context, req ctr
 
 		cert := cmapi.Certificate{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      req.Name,
-				Namespace: req.Namespace,
+				Name:        req.Name,
+				Namespace:   req.Namespace,
+				Annotations: dicp.opts.AdditionalAnnotations,
 			},
 			Spec: desiredSpec,
 		}


### PR DESCRIPTION
Example of this working from running an e2e test:

```yaml
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  annotations:
    custom.cert-manager.io/policy-name: istio-csr
    custom.cert-manager.io/second-annotation: some-value
  creationTimestamp: "2024-09-02T14:55:20Z"
  generation: 1
  name: istiod-dynamic
  namespace: istio-system
  resourceVersion: "779"
  uid: f157f3fd-2e9d-4d8e-900e-651920490cde
spec:
  commonName: istiod.istio-system.svc
  dnsNames:
  - istiod.istio-system.svc
  duration: 1h0m0s
  issuerRef:
    group: cert-manager.io
    kind: Issuer
    name: istio-ca
  privateKey:
    algorithm: RSA
    rotationPolicy: Always
    size: 2048
  renewBefore: 30m0s
  revisionHistoryLimit: 1
  secretName: istiod-tls
  uris:
  - spiffe://foo.bar/ns/istio-system/sa/istiod-service-account
status:
  conditions:
  - lastTransitionTime: "2024-09-02T14:55:20Z"
    message: Certificate is up to date and has not expired
    observedGeneration: 1
    reason: Ready
    status: "True"
    type: Ready
  notAfter: "2024-09-02T15:55:20Z"
  notBefore: "2024-09-02T14:55:20Z"
  renewalTime: "2024-09-02T15:25:20Z"
  revision: 1
```