### PR TITLE
Tweak roles to fix permission errors

### DIFF
--- a/deploy/charts/istio-csr/templates/role.yaml
+++ b/deploy/charts/istio-csr/templates/role.yaml
@@ -26,16 +26,3 @@ rules:
   verbs: ["get", "list", "watch"]
   resourceNames: [{{ . | quote }}]
 {{- end }}
-{{- if eq (toString .Values.app.tls.istiodCertificateEnable) "dynamic" }}
-- apiGroups:
-  - "cert-manager.io"
-  resources:
-  - "certificates"
-  verbs:
-  - "get"
-  - "create"
-  - "update"
-  - "delete"
-  - "watch"
-  - "list"
-{{- end }}

--- a/deploy/charts/istio-csr/templates/role_dynamic_istiod.yaml
+++ b/deploy/charts/istio-csr/templates/role_dynamic_istiod.yaml
@@ -1,0 +1,22 @@
+{{- if eq (toString .Values.app.tls.istiodCertificateEnable) "dynamic" }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    {{- include "cert-manager-istio-csr.labels" . | nindent 4 }}
+  name: {{ include "cert-manager-istio-csr.name" . }}-dynamic-istiod
+  namespace: {{ .Values.app.istio.namespace }}
+rules:
+- apiGroups:
+  - "cert-manager.io"
+  resources:
+  - "certificates"
+  verbs:
+  - "get"
+  - "create"
+  - "update"
+  - "delete"
+  - "watch"
+  - "list"
+{{- end }}
+

--- a/deploy/charts/istio-csr/templates/role_leases.yaml
+++ b/deploy/charts/istio-csr/templates/role_leases.yaml
@@ -16,4 +16,6 @@ rules:
   - "update"
   - "watch"
   - "list"
-
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]

--- a/deploy/charts/istio-csr/templates/rolebinding_dynamic_istiod.yaml
+++ b/deploy/charts/istio-csr/templates/rolebinding_dynamic_istiod.yaml
@@ -1,0 +1,16 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "cert-manager-istio-csr.name" . }}-dynamic-istiod
+  namespace: {{ .Values.app.istio.namespace }}
+  labels:
+    {{- include "cert-manager-istio-csr.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "cert-manager-istio-csr.name" . }}-dynamic-istiod
+subjects:
+- kind: ServiceAccount
+  name: {{ include "cert-manager-istio-csr.name" . }}
+  namespace: {{ .Release.Namespace }}
+


### PR DESCRIPTION
There are two issues here; first, there was a missing permission to create events in the lease namespace if the lease namespace differs from `.Values.app.certmanager.namespace`. That was observed with the below error:

```text
E0827 11:25:35.882363       1 event.go:359] "Server rejected event (will not retry!)" err="events is forbidden: User \"system:serviceaccount:venafi:cert-manager-istio-csr\" cannot create resource \"events\" in API
group \"\" in the namespace \"asd\"" event="&Event{ObjectMeta:{istio-csr.17ef92345b7ae172  asd 0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] [] []},InvolvedObject:ObjectReference{Kind:Lease,Na
mespace:asd,Name:istio-csr,UID:ec187de6-fca5-4bb6-accb-ce601cefafb5,APIVersion:coordination.k8s.io/v1,ResourceVersion:245173,FieldPath:,},Reason:LeaderElection,Message:cert-manager-istio-csr-65f98db858-966lz_68e
4de58-2685-42fc-90a4-ae5ee49e2472 became leader,Source:EventSource{Component:cert-manager-istio-csr-65f98db858-966lz_68e4de58-2685-42fc-90a4-ae5ee49e2472,Host:,},FirstTimestamp:2024-08-27 11:25:35.876923762 +0000 U
TC m=+15.995353297,LastTimestamp:2024-08-27 11:25:35.876923762 +0000 UTC m=+15.995353297,Count:1,Type:Normal,EventTime:0001-01-01 00:00:00 +0000 UTC,Series:nil,Action:,Related:nil,ReportingController:cert-manager-i
stio-csr-65f98db858-966lz_68e4de58-2685-42fc-90a4-ae5ee49e2472,ReportingInstance:,}"
```

Second, the permissions for creating the dynamic istiod cert were tied to the wrong namespace. `.Values.app.certmanager.namespace` isn't always the same as `.Values.app.istio.namespace`.