### PR TITLE
Handle initial issuer config for dynamic istiod cert

### DIFF
--- a/pkg/istiodcert/worker.go
+++ b/pkg/istiodcert/worker.go
@@ -95,6 +95,10 @@ func New(log logr.Logger, restConfig *rest.Config, opts Options, issuerChangeNot
 // It waits for a notification of an issuer change, and when it gets one it
 // triggers reconciliation of the dynamic istiod cert.
 func (dicp *DynamicIstiodCertProvisioner) Start(ctx context.Context) error {
+	if dicp.initialIssuerRef != nil {
+		dicp.handleNewIssuer(dicp.initialIssuerRef)
+	}
+
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
Currently, if you specify runtime config with an initial issuer and a dynamic istiod cert, the cert will silently never be created until runtime config is created.

This isn't a usual mode of operation, but it is confusing when it happens. By checking for initial issuer config we can trigger the cert to be created.