### PR TITLE
fix: expose ALPN in TLS handshake

### DIFF
--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -427,8 +427,11 @@ func (p *Provider) fetchCertificate(ctx context.Context) (time.Time, error) {
 	p.tlsConfig = &tls.Config{
 		MinVersion:   tls.VersionTLS12,
 		Certificates: []tls.Certificate{tlsCert},
-		ClientAuth:   tls.VerifyClientCertIfGiven,
-		ClientCAs:    peerCertVerifier.GetGeneralCertPool(),
+		// Advertise ALPN, required in modern gRPC versions
+		// Typically gRPC sets this for us, but since this tls.Config ultimately gets returned in GetConfigForClient it doesn't.
+		NextProtos: []string{"h2"},
+		ClientAuth: tls.VerifyClientCertIfGiven,
+		ClientCAs:  peerCertVerifier.GetGeneralCertPool(),
 		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 			err := peerCertVerifier.VerifyPeerCert(rawCerts, verifiedChains)
 			if err != nil {


### PR DESCRIPTION
New versions of gRPC-go are enforcing the `h2` ALPN to be presented during the TLS handshake. See
https://pkg.go.dev/google.golang.org/grpc/internal/envconfig#pkg-variables `GRPC_ENFORCE_ALPN_ENABLED`. The TLS server here isn't automatically getting this set due to usage of GetConfigForClient.

This properly sets it.

Without this, istio-csr will be incompatible with Istio 1.24, which upgrades the gRPC version. Note this can be worked around by setting `GRPC_ENFORCE_ALPN_ENABLED=false` on the proxy container, which Istio is able to do -- so there is an escape hatch for users.

The Istio logs look like
`"transport: authentication handshake failed: credentials: cannot check peer: missing selected ALPN property"`