### PR TITLE
fix(helm): quote `istiodAdditionalDNSNames` to support wildcard domains

### DIFF
--- a/deploy/charts/istio-csr/templates/certificate.yaml
+++ b/deploy/charts/istio-csr/templates/certificate.yaml
@@ -35,7 +35,7 @@ spec:
   {{- end }}
   {{- if .Values.app.tls.istiodAdditionalDNSNames }}
   {{- range .Values.app.tls.istiodAdditionalDNSNames }}
-  - {{ . }}
+  - {{ . | quote }}
   {{- end }}
   {{- end }}
   uris:


### PR DESCRIPTION
Description
---

Fixes a helm chart issue where wildcard DNS names at `app.tls.istiodAdditionalDNSNames` were causing YAML parsing errors. Without quotes, YAML treats strings starting with an asterisk (*) as special characters, leading to parsing issues.

More details
---

With the proposed fix, the helm template evaluates the wildcard domain properly. See [helm playground](https://helm-playground.com/#t=LQhQBMDsGcDkEMC2BTaAuUACTBvHxMBLAM0wDoA1eAGwFdUzDoAXQge3AEFxxDW3INACKwAyghTRMAX2lZc%2BTACd4kAObJyVOgyb8uPPu0HUR4pKhlzsBPOUwAfTAEdabZslny8BZJHBW3op%2BAbJAA&v=LQhQEsGcBdwewCYEEEPLOA7AhgGwCIByAyodgLYCmkAXAAQDaARAFQB0UGwkAnjJeTaQAbgGMmAGjpNo1aEwC6QA).

Without the quotes, the template throws an error.

```console
the generated YAML may contain parsing errors. 
Converting it to JSON failed: error converting YAML to JSON: yaml: line 3: did not find expected alphabetic or numeric character
```