### PR TITLE
Various e2e setup tweaks

### DIFF
--- a/make/test-e2e.mk
+++ b/make/test-e2e.mk
@@ -15,6 +15,10 @@
 ISTIO_VERSION ?= 1.23.2
 ISTIO_CONFIG_FILE ?= ./make/config/istio/istio-config-default.yaml
 
+.PHONY: print-latest-istio-version
+print-latest-istio-version:
+	@curl -sSL --show-error -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/istio/istio/releases | jq -r '.[].tag_name' | sort -rV | head -n1
+
 $(bin_dir)/scratch/istioctl-$(ISTIO_VERSION): | $(bin_dir)/scratch/
 	curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$(ISTIO_VERSION) sh -
 	mv istio-$(ISTIO_VERSION)/bin/istioctl $(bin_dir)/scratch/istioctl-$(ISTIO_VERSION)

--- a/make/test-e2e.mk
+++ b/make/test-e2e.mk
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ISTIO_VERSION ?= 1.22.2
+ISTIO_VERSION ?= 1.23.2
 ISTIO_CONFIG_FILE ?= ./make/config/istio/istio-config-default.yaml
 
 $(bin_dir)/scratch/istioctl-$(ISTIO_VERSION): | $(bin_dir)/scratch/

--- a/make/test-e2e.mk
+++ b/make/test-e2e.mk
@@ -92,6 +92,7 @@ INSTALL_OPTIONS += -f ./make/config/istio-csr-values.yaml
 
 test-e2e-deps: e2e-setup-cert-manager
 test-e2e-deps: e2e-create-cert-manager-istio-resources
+test-e2e-deps: ISTIO_INSTALL_OPTIONS :=
 
 test-e2e-deps-sidecars: test-e2e-deps
 test-e2e-deps-sidecars: install
@@ -100,7 +101,6 @@ test-e2e-deps-sidecars: e2e-setup-istio
 test-e2e-deps-ambient: test-e2e-deps
 test-e2e-deps-ambient: INSTALL_OPTIONS += --set app.server.caTrustedNodeAccounts="istio-system/ztunnel"
 test-e2e-deps-ambient: install
-test-e2e-deps-ambient: ISTIO_INSTALL_OPTIONS :=
 test-e2e-deps-ambient: ISTIO_INSTALL_OPTIONS += --set profile=ambient
 test-e2e-deps-ambient: e2e-setup-istio
 


### PR DESCRIPTION
Most importantly, adds a command for printing the latest istio version.

The istio install script we use for downloading istioctl ignores pre-releases and we want to include them, so this adds a quick oneliner to fetch the latest versions and pick the newest.

This will allow us to add a periodic test which runs with the latest released version of istio, preventing us from being surprised by a breaking change upstream in the future.