### PR TITLE
Upgrade go version to 1.23.1 to clean image scans.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/istio-csr
 
-go 1.23.0
+go 1.23.1
 
 // https://github.com/darccio/mergo/blob/cde9f0ea26cccb1168ee3900cf8ca457bb928c3c/README.md#100
 replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16


### PR DESCRIPTION
Mostly just house keeping but should be a insignificant change.
[CVE-2024-34158](https://access.redhat.com/security/cve/cve-2024-34158)
[CVE-2024-34156](https://access.redhat.com/security/cve/CVE-2024-34156)