### PR TITLE
Add Helm chart OCI release to GH automation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ env:
   VERSION: ${{ github.ref_name }}
 
 jobs:
-  build_images:
+  build_and_push:
     runs-on: ubuntu-latest
 
     permissions:
@@ -36,22 +36,16 @@ jobs:
       - id: release
         run: make release
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.release.outputs.RELEASE_HELM_CHART_NAME }}-${{ steps.release.outputs.RELEASE_HELM_CHART_VERSION }}.tgz
-          path: ${{ steps.release.outputs.RELEASE_HELM_CHART_TAR }}
-          if-no-files-found: error
-
     outputs:
       RELEASE_OCI_MANAGER_IMAGE: ${{ steps.release.outputs.RELEASE_OCI_MANAGER_IMAGE }}
       RELEASE_OCI_MANAGER_TAG: ${{ steps.release.outputs.RELEASE_OCI_MANAGER_TAG }}
-      RELEASE_HELM_CHART_NAME: ${{ steps.release.outputs.RELEASE_HELM_CHART_NAME }}
+      RELEASE_HELM_CHART_IMAGE: ${{ steps.release.outputs.RELEASE_HELM_CHART_IMAGE }}
       RELEASE_HELM_CHART_VERSION: ${{ steps.release.outputs.RELEASE_HELM_CHART_VERSION }}
 
   github_release:
     runs-on: ubuntu-latest
 
-    needs: build_images
+    needs: build_and_push
 
     permissions:
       contents: write # needed for creating a PR
@@ -60,15 +54,10 @@ jobs:
     steps:
       - run: |
           touch .notes-file
-          echo "OCI_MANAGER_IMAGE: ${{ needs.build_images.outputs.RELEASE_OCI_MANAGER_IMAGE }}" >> .notes-file
-          echo "OCI_MANAGER_TAG: ${{ needs.build_images.outputs.RELEASE_OCI_MANAGER_TAG }}" >> .notes-file
-          echo "HELM_CHART_NAME: ${{ needs.build_images.outputs.RELEASE_HELM_CHART_NAME }}" >> .notes-file
-          echo "HELM_CHART_VERSION: ${{ needs.build_images.outputs.RELEASE_HELM_CHART_VERSION }}" >> .notes-file
-
-      - id: chart_download
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ needs.build_images.outputs.RELEASE_HELM_CHART_NAME }}-${{ needs.build_images.outputs.RELEASE_HELM_CHART_VERSION }}.tgz
+          echo "OCI_MANAGER_IMAGE: ${{ needs.build_and_push.outputs.RELEASE_OCI_MANAGER_IMAGE }}" >> .notes-file
+          echo "OCI_MANAGER_TAG: ${{ needs.build_and_push.outputs.RELEASE_OCI_MANAGER_TAG }}" >> .notes-file
+          echo "HELM_CHART_IMAGE: ${{ needs.build_and_push.outputs.RELEASE_HELM_CHART_IMAGE }}" >> .notes-file
+          echo "HELM_CHART_VERSION: ${{ needs.build_and_push.outputs.RELEASE_HELM_CHART_VERSION }}" >> .notes-file
 
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,7 +68,3 @@ jobs:
             --draft \
             --verify-tag \
             --notes-file .notes-file
-          
-          gh release upload "$VERSION" \
-            --repo="$GITHUB_REPOSITORY" \
-            "${{ steps.chart_download.outputs.download-path }}/${{ needs.build_images.outputs.RELEASE_HELM_CHART_NAME }}-${{ needs.build_images.outputs.RELEASE_HELM_CHART_VERSION }}.tgz"

--- a/klone.yaml
+++ b/klone.yaml
@@ -35,7 +35,7 @@ targets:
     - folder_name: helm
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 25ec11345ab139986fad5fe7ffb5503069e6f81b
+      repo_hash: fbd26411777b12c2574d05f146cee617c6c50b63
       repo_path: modules/helm
     - folder_name: help
       repo_url: https://github.com/cert-manager/makefile-modules.git

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -32,12 +32,9 @@ deploy_name := istio-csr
 deploy_namespace := cert-manager
 
 helm_chart_source_dir := deploy/charts/istio-csr
-helm_chart_name := cert-manager-istio-csr
+helm_chart_image_name := quay.io/jetstack/charts/cert-manager-istio-csr
 helm_chart_version := $(VERSION)
 helm_labels_template_name := cert-manager-istio-csr.labels
-helm_docs_use_helm_tool := 1
-helm_generate_schema := 1
-helm_verify_values := 1
 
 golangci_lint_config := .golangci.yaml
 

--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -25,13 +25,13 @@ include make/test-unit.mk
 .PHONY: release
 ## Publish all release artifacts (image + helm chart)
 ## @category [shared] Release
-release: $(helm_chart_archive)
+release:
 	$(MAKE) oci-push-manager
+	$(MAKE) helm-chart-oci-push
 
 	@echo "RELEASE_OCI_MANAGER_IMAGE=$(oci_manager_image_name)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_OCI_MANAGER_TAG=$(oci_manager_image_tag)" >> "$(GITHUB_OUTPUT)"
-	@echo "RELEASE_HELM_CHART_NAME=$(helm_chart_name)" >> "$(GITHUB_OUTPUT)"
+	@echo "RELEASE_HELM_CHART_IMAGE=$(helm_chart_image_name)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_HELM_CHART_VERSION=$(helm_chart_version)" >> "$(GITHUB_OUTPUT)"
-	@echo "RELEASE_HELM_CHART_TAR=$(helm_chart_archive)" >> "$(GITHUB_OUTPUT)"
 
 	@echo "Release complete!"


### PR DESCRIPTION
Adds logic for pushing the Helm chart to an OCI registry (and adding a non-v-prefixed tag)

See https://github.com/cert-manager/makefile-modules/pull/219 for more info.