### PR TITLE
Fix helm chart typos

### DIFF
--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -128,7 +128,7 @@ Create a Prometheus ServiceMonitor resource.
 > default
 > ```
 
-The value for the "prometheus" label on the ServiceMonitor. This allows for multiple Prometheus instances selecting difference ServiceMonitors using label selectors.
+The value for the "prometheus" label on the ServiceMonitor. This allows for multiple Prometheus instances selecting different ServiceMonitors using label selectors.
 #### **app.metrics.service.servicemonitor.interval** ~ `string`
 > Default value:
 > ```yaml
@@ -156,7 +156,7 @@ Additional labels to give the ServiceMonitor resource.
 > false
 > ```
 
-Create the runtime-configuration ConfigMap
+Create the runtime-configuration ConfigMap.
 #### **app.runtimeConfiguration.name** ~ `string`
 > Default value:
 > ```yaml
@@ -286,9 +286,7 @@ An optional file location to a PEM encoded root CA that the root CA. ConfigMap i
 > 1h
 > ```
 
-Requested duration of gRPC serving certificate. Will be automatically renewed.  
-Based on NIST 800-204A recommendations (SM-DR13).  
-https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf
+Requested duration of gRPC serving certificate. Will be automatically renewed. Based on [NIST 800-204A recommendations (SM-DR13)](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf).
 #### **app.tls.istiodCertificateEnable** ~ `boolean,string,null`
 > Default value:
 > ```yaml
@@ -303,7 +301,7 @@ If true, create the istiod certificate using a cert-manager certificate as part 
 > 1h
 > ```
 
-Requested duration of istio's Certificate. Will be automatically renewed. Default is based on NIST 800-204A recommendations (SM-DR13). https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf. Warning: cert-manager does not allow a duration on Certificates less than 1 hour.
+Requested duration of istio's Certificate. Will be automatically renewed. Default is based on [NIST 800-204A recommendations (SM-DR13)](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf). Warning: cert-manager does not allow a duration on Certificates less than 1 hour.
 #### **app.tls.istiodCertificateRenewBefore** ~ `string`
 > Default value:
 > ```yaml
@@ -353,9 +351,7 @@ The istio cluster ID to verify incoming CSRs.
 > 1h
 > ```
 
-Maximum validity duration that can be requested for a certificate. istio-csr will request a duration of the smaller of this value, and that of the incoming gRPC CSR.  
-Based on NIST 800-204A recommendations (SM-DR13).  
-https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf
+Maximum validity duration that can be requested for a certificate. istio-csr will request a duration of the smaller of this value, and that of the incoming gRPC CSR. Based on [NIST 800-204A recommendations (SM-DR13)](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf).
 #### **app.server.serving.address** ~ `string`
 > Default value:
 > ```yaml
@@ -390,7 +386,7 @@ The type of private key to generate for the serving certificate. Only RSA (defau
 > ""
 > ```
 
-A comma-separated list of service accounts that are allowed to use node authentication for CSRs, eg. "istio-system/ztunnel"
+A comma-separated list of service accounts that are allowed to use node authentication for CSRs, eg. "istio-system/ztunnel".
 #### **app.istio.revisions[0]** ~ `string`
 > Default value:
 > ```yaml
@@ -457,7 +453,7 @@ Optional extra annotations for pod.
 > []
 > ```
 
-Optional extra volumes. Useful for mounting custom root CAs  
+Optional extra volumes. Useful for mounting custom root CAs.  
   
 For example:
 
@@ -473,7 +469,7 @@ volumes:
 > []
 > ```
 
-Optional extra volume mounts. Useful for mounting custom root CAs  
+Optional extra volume mounts. Useful for mounting custom root CAs.  
   
 For example:
 
@@ -488,8 +484,7 @@ volumeMounts:
 > {}
 > ```
 
-Kubernetes pod resources  
-ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/  
+Kubernetes [pod resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).  
   
 For example:
 
@@ -528,7 +523,7 @@ resources:
 > {}
 > ```
 
-Expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core  
+Expects input structure as per [specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core).  
   
 For example:
 
@@ -549,7 +544,7 @@ affinity:
 > []
 > ```
 
-Expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core  
+Expects input structure as per [specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core).  
   
 For example:
 
@@ -593,14 +588,14 @@ Kubernetes node selector: node labels for pod assignment.
 > {}
 > ```
 
-Labels to apply to all resources
+Labels to apply to all resources.
 #### **extraObjects** ~ `array`
 > Default value:
 > ```yaml
 > []
 > ```
 
-Create resources alongside installing istio-csr, via Helm values. Can accept an array of YAML-formatted resources. Each array entry can include multiple YAML documents, separated by '---'  
+Create resources alongside installing istio-csr, via Helm values. Can accept an array of YAML-formatted resources. Each array entry can include multiple YAML documents, separated by '---'.  
   
 For example:
 

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -121,7 +121,7 @@ Service type to expose metrics.
 > false
 > ```
 
-Create Prometheus ServiceMonitor resource for approver-policy.
+Create a Prometheus ServiceMonitor resource.
 #### **app.metrics.service.servicemonitor.prometheusInstance** ~ `string`
 > Default value:
 > ```yaml

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -71,7 +71,7 @@
     },
     "helm-values.affinity": {
       "default": {},
-      "description": "Expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core\n\nFor example:\naffinity:\n  nodeAffinity:\n   requiredDuringSchedulingIgnoredDuringExecution:\n     nodeSelectorTerms:\n     - matchExpressions:\n       - key: foo.bar.com/role\n         operator: In\n         values:\n         - master",
+      "description": "Expects input structure as per [specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core).\n\nFor example:\naffinity:\n  nodeAffinity:\n   requiredDuringSchedulingIgnoredDuringExecution:\n     nodeSelectorTerms:\n     - matchExpressions:\n       - key: foo.bar.com/role\n         operator: In\n         values:\n         - master",
       "type": "object"
     },
     "helm-values.app": {
@@ -325,7 +325,7 @@
     },
     "helm-values.app.metrics.service.servicemonitor.prometheusInstance": {
       "default": "default",
-      "description": "The value for the \"prometheus\" label on the ServiceMonitor. This allows for multiple Prometheus instances selecting difference ServiceMonitors using label selectors.",
+      "description": "The value for the \"prometheus\" label on the ServiceMonitor. This allows for multiple Prometheus instances selecting different ServiceMonitors using label selectors.",
       "type": "string"
     },
     "helm-values.app.metrics.service.servicemonitor.scrapeTimeout": {
@@ -377,7 +377,7 @@
     },
     "helm-values.app.runtimeConfiguration.create": {
       "default": false,
-      "description": "Create the runtime-configuration ConfigMap",
+      "description": "Create the runtime-configuration ConfigMap.",
       "type": "boolean"
     },
     "helm-values.app.runtimeConfiguration.issuer": {
@@ -457,7 +457,7 @@
     },
     "helm-values.app.server.caTrustedNodeAccounts": {
       "default": "",
-      "description": "A comma-separated list of service accounts that are allowed to use node authentication for CSRs, eg. \"istio-system/ztunnel\"",
+      "description": "A comma-separated list of service accounts that are allowed to use node authentication for CSRs, eg. \"istio-system/ztunnel\".",
       "type": "string"
     },
     "helm-values.app.server.clusterID": {
@@ -467,7 +467,7 @@
     },
     "helm-values.app.server.maxCertificateDuration": {
       "default": "1h",
-      "description": "Maximum validity duration that can be requested for a certificate. istio-csr will request a duration of the smaller of this value, and that of the incoming gRPC CSR.\nBased on NIST 800-204A recommendations (SM-DR13).\nhttps://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf",
+      "description": "Maximum validity duration that can be requested for a certificate. istio-csr will request a duration of the smaller of this value, and that of the incoming gRPC CSR. Based on [NIST 800-204A recommendations (SM-DR13)](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf).",
       "type": "string"
     },
     "helm-values.app.server.serving": {
@@ -556,7 +556,7 @@
     },
     "helm-values.app.tls.certificateDuration": {
       "default": "1h",
-      "description": "Requested duration of gRPC serving certificate. Will be automatically renewed.\nBased on NIST 800-204A recommendations (SM-DR13).\nhttps://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf",
+      "description": "Requested duration of gRPC serving certificate. Will be automatically renewed. Based on [NIST 800-204A recommendations (SM-DR13)](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf).",
       "type": "string"
     },
     "helm-values.app.tls.istiodAdditionalDNSNames": {
@@ -567,7 +567,7 @@
     },
     "helm-values.app.tls.istiodCertificateDuration": {
       "default": "1h",
-      "description": "Requested duration of istio's Certificate. Will be automatically renewed. Default is based on NIST 800-204A recommendations (SM-DR13). https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf. Warning: cert-manager does not allow a duration on Certificates less than 1 hour.",
+      "description": "Requested duration of istio's Certificate. Will be automatically renewed. Default is based on [NIST 800-204A recommendations (SM-DR13)](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf). Warning: cert-manager does not allow a duration on Certificates less than 1 hour.",
       "type": "string"
     },
     "helm-values.app.tls.istiodCertificateEnable": {
@@ -599,7 +599,7 @@
     },
     "helm-values.commonLabels": {
       "default": {},
-      "description": "Labels to apply to all resources",
+      "description": "Labels to apply to all resources.",
       "type": "object"
     },
     "helm-values.deploymentAnnotations": {
@@ -614,7 +614,7 @@
     },
     "helm-values.extraObjects": {
       "default": [],
-      "description": "Create resources alongside installing istio-csr, via Helm values. Can accept an array of YAML-formatted resources. Each array entry can include multiple YAML documents, separated by '---'\n\nFor example:\nextraObjects:\n  - |\n    apiVersion: v1\n    kind: ConfigMap\n    metadata:\n      name: '{{ template \"cert-manager-istio-csr.fullname\" . }}-extra-configmap'",
+      "description": "Create resources alongside installing istio-csr, via Helm values. Can accept an array of YAML-formatted resources. Each array entry can include multiple YAML documents, separated by '---'.\n\nFor example:\nextraObjects:\n  - |\n    apiVersion: v1\n    kind: ConfigMap\n    metadata:\n      name: '{{ template \"cert-manager-istio-csr.fullname\" . }}-extra-configmap'",
       "items": {},
       "type": "array"
     },
@@ -698,7 +698,7 @@
     },
     "helm-values.resources": {
       "default": {},
-      "description": "Kubernetes pod resources\nref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\n\nFor example:\nresources:\n  limits:\n    cpu: 100m\n    memory: 128Mi\n  requests:\n    cpu: 100m\n    memory: 128Mi",
+      "description": "Kubernetes [pod resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).\n\nFor example:\nresources:\n  limits:\n    cpu: 100m\n    memory: 128Mi\n  requests:\n    cpu: 100m\n    memory: 128Mi",
       "type": "object"
     },
     "helm-values.securityContext": {
@@ -781,7 +781,7 @@
     },
     "helm-values.tolerations": {
       "default": [],
-      "description": "Expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core\n\nFor example:\ntolerations:\n- key: foo.bar.com/role\n  operator: Equal\n  value: master\n  effect: NoSchedule",
+      "description": "Expects input structure as per [specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core).\n\nFor example:\ntolerations:\n- key: foo.bar.com/role\n  operator: Equal\n  value: master\n  effect: NoSchedule",
       "items": {},
       "type": "array"
     },
@@ -793,13 +793,13 @@
     },
     "helm-values.volumeMounts": {
       "default": [],
-      "description": "Optional extra volume mounts. Useful for mounting custom root CAs\n\nFor example:\nvolumeMounts:\n- name: root-ca\n  mountPath: /etc/tls",
+      "description": "Optional extra volume mounts. Useful for mounting custom root CAs.\n\nFor example:\nvolumeMounts:\n- name: root-ca\n  mountPath: /etc/tls",
       "items": {},
       "type": "array"
     },
     "helm-values.volumes": {
       "default": [],
-      "description": "Optional extra volumes. Useful for mounting custom root CAs\n\nFor example:\nvolumes:\n- name: root-ca\n  secret:\n    secretName: root-cert",
+      "description": "Optional extra volumes. Useful for mounting custom root CAs.\n\nFor example:\nvolumes:\n- name: root-ca\n  secret:\n    secretName: root-cert",
       "items": {},
       "type": "array"
     }

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -310,7 +310,7 @@
     },
     "helm-values.app.metrics.service.servicemonitor.enabled": {
       "default": false,
-      "description": "Create Prometheus ServiceMonitor resource for approver-policy.",
+      "description": "Create a Prometheus ServiceMonitor resource.",
       "type": "boolean"
     },
     "helm-values.app.metrics.service.servicemonitor.interval": {

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -65,7 +65,7 @@ app:
         # Create a Prometheus ServiceMonitor resource.
         enabled: false
         # The value for the "prometheus" label on the ServiceMonitor. This allows
-        # for multiple Prometheus instances selecting difference ServiceMonitors
+        # for multiple Prometheus instances selecting different ServiceMonitors
         # using label selectors.
         prometheusInstance: default
         # The interval that the Prometheus will scrape for metrics.
@@ -87,7 +87,7 @@ app:
   runtimeIssuanceConfigMap: ""
 
   runtimeConfiguration:
-    # Create the runtime-configuration ConfigMap
+    # Create the runtime-configuration ConfigMap.
     create: false
 
     # Name of a ConfigMap in the installation namespace to watch, providing
@@ -166,8 +166,7 @@ app:
     - cert-manager-istio-csr.cert-manager.svc
     # Requested duration of gRPC serving certificate. Will be automatically
     # renewed.
-    # Based on NIST 800-204A recommendations (SM-DR13).
-    # https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf
+    # Based on [NIST 800-204A recommendations (SM-DR13)](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf).
     certificateDuration: 1h
 
     # If true, create the istiod certificate using a cert-manager certificate as part
@@ -176,8 +175,7 @@ app:
     # +docs:type=boolean,string,null
     istiodCertificateEnable: true
     # Requested duration of istio's Certificate. Will be automatically renewed.
-    # Default is based on NIST 800-204A recommendations (SM-DR13).
-    # https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf
+    # Default is based on [NIST 800-204A recommendations (SM-DR13)](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf).
     # Warning: cert-manager does not allow a duration on Certificates less than 1 hour.
     istiodCertificateDuration: 1h
     # Amount of time to wait before trying to renew the istiod certificate.
@@ -201,8 +199,7 @@ app:
     # Maximum validity duration that can be requested for a certificate.
     # istio-csr will request a duration of the smaller of this value, and that of
     # the incoming gRPC CSR.
-    # Based on NIST 800-204A recommendations (SM-DR13).
-    # https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf
+    # Based on [NIST 800-204A recommendations (SM-DR13)](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf).
     maxCertificateDuration: 1h
     serving:
       # Container address to serve istio-csr gRPC service.
@@ -214,7 +211,7 @@ app:
       # The type of private key to generate for the serving certificate. Only RSA (default) and ECDSA are supported.
       # NB: This variable is named incorrectly; it controls private key algorithm, not signature algorithm.
       signatureAlgorithm: "RSA"
-    # A comma-separated list of service accounts that are allowed to use node authentication for CSRs, eg. "istio-system/ztunnel"
+    # A comma-separated list of service accounts that are allowed to use node authentication for CSRs, eg. "istio-system/ztunnel".
     caTrustedNodeAccounts: ""
 
   istio:
@@ -263,7 +260,7 @@ podLabels: {}
 # Optional extra annotations for pod.
 podAnnotations: {}
 
-# Optional extra volumes. Useful for mounting custom root CAs
+# Optional extra volumes. Useful for mounting custom root CAs.
 #
 # For example:
 #  volumes:
@@ -272,7 +269,7 @@ podAnnotations: {}
 #      secretName: root-cert
 volumes: []
 
-# Optional extra volume mounts. Useful for mounting custom root CAs
+# Optional extra volume mounts. Useful for mounting custom root CAs.
 #
 # For example:
 #  volumeMounts:
@@ -280,8 +277,7 @@ volumes: []
 #    mountPath: /etc/tls
 volumeMounts: []
 
-# Kubernetes pod resources
-# ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+# Kubernetes [pod resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
 #
 # For example:
 #  resources:
@@ -293,8 +289,7 @@ volumeMounts: []
 #      memory: 128Mi
 resources: {}
 
-# Kubernetes security context
-# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+# Kubernetes [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 #
 # See the default values for an example.
 securityContext:
@@ -305,7 +300,7 @@ securityContext:
     drop:
     - ALL
 
-# Expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
+# Expects input structure as per [specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core).
 #
 # For example:
 #   affinity:
@@ -319,7 +314,7 @@ securityContext:
 #            - master
 affinity: {}
 
-# Expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core
+# Expects input structure as per [specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core).
 #
 # For example:
 #   tolerations:
@@ -346,11 +341,11 @@ topologySpreadConstraints: []
 nodeSelector:
   kubernetes.io/os: linux
 
-# Labels to apply to all resources
+# Labels to apply to all resources.
 commonLabels: {}
 
 # Create resources alongside installing istio-csr, via Helm values. Can accept an array of YAML-formatted
-# resources. Each array entry can include multiple YAML documents, separated by '---'
+# resources. Each array entry can include multiple YAML documents, separated by '---'.
 #
 # For example:
 # extraObjects:

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -1,7 +1,7 @@
 # nameOverride replaces the name of the chart in the Chart.yaml file, when this
 # is used to construct Kubernetes object names.
 # +docs:property
-# nameOverride: approver-policy
+# nameOverride: istio-csr
 
 # Number of replicas of istio-csr to run.
 replicaCount: 1
@@ -62,7 +62,7 @@ app:
       type: ClusterIP
       # The ServiceMonitor resource for this Service.
       servicemonitor:
-        # Create Prometheus ServiceMonitor resource for approver-policy.
+        # Create a Prometheus ServiceMonitor resource.
         enabled: false
         # The value for the "prometheus" label on the ServiceMonitor. This allows
         # for multiple Prometheus instances selecting difference ServiceMonitors
@@ -133,7 +133,7 @@ app:
     #      value: istio-csr
     additionalAnnotations: []
     issuer:
-      # Enable the default issuer, this is the issuer used when no runtime 
+      # Enable the default issuer, this is the issuer used when no runtime
       # configuration is provided.
       #
       # When enabled the istio-csr Pod will not be "Ready" until the issuer


### PR DESCRIPTION
While testing istio-csr recently, I noticed various references to `approver-policy` in the Helm chart values.
I've fixed those and also:
 * Added missing full stops at the end of comments (for consistency with the majority of the Helm values comments).
 * Turned some unformatted URLs into markdown links, to save having to manually make those changes when we publish the Helm chart documentation. Here for example: https://docs.venafi.cloud/vaas/k8s-components/c-istiocsr-helmvalues/#tolerations
 * A couple of other drive by typo fixes. 

