### PR TITLE
Add app.server.certificateDuration

### DIFF
--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -299,6 +299,11 @@ func (o *Options) addServerFlags(fs *pflag.FlagSet) {
 		"Maximum duration a client certificate can be requested and valid for. Will "+
 			"override with this value if the requested duration is larger")
 
+	fs.DurationVarP(&o.Server.ClientCertificateDuration,
+		"client-certificate-duration", "r", 0,
+		"Specify the custom duration for client certificates. "+
+			"Overrides the requested duration.")
+
 	fs.StringVar(&o.Server.ClusterID, "cluster-id", "Kubernetes",
 		"The ID of the istio cluster to verify.")
 

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -352,6 +352,14 @@ The istio cluster ID to verify incoming CSRs.
 > ```
 
 Maximum validity duration that can be requested for a certificate. istio-csr will request a duration of the smaller of this value, and that of the incoming gRPC CSR. Based on [NIST 800-204A recommendations (SM-DR13)](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf).
+#### **app.server.certificateDuration** ~ `number`
+> Default value:
+> ```yaml
+> 0
+> ```
+
+Custom validity duration for a certificate.  
+istio-csr will override a duration of the incoming gRPC CSR. Set to 0 to disable overriding (default behavior).
 #### **app.server.serving.address** ~ `string`
 > Default value:
 > ```yaml

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -100,6 +100,7 @@ spec:
           # server
           - "--cluster-id={{.Values.app.server.clusterID}}"
           - "--max-client-certificate-duration={{.Values.app.server.maxCertificateDuration}}"
+          - "--client-certificate-duration={{.Values.app.server.certificateDuration}}"
           - "--serving-address={{.Values.app.server.serving.address}}:{{.Values.app.server.serving.port}}"
           - "--serving-certificate-key-size={{.Values.app.server.serving.certificateKeySize}}"
           - "--serving-signature-algorithm={{ .Values.app.server.serving.signatureAlgorithm }}"

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -429,6 +429,9 @@
         "caTrustedNodeAccounts": {
           "$ref": "#/$defs/helm-values.app.server.caTrustedNodeAccounts"
         },
+        "certificateDuration": {
+          "$ref": "#/$defs/helm-values.app.server.certificateDuration"
+        },
         "clusterID": {
           "$ref": "#/$defs/helm-values.app.server.clusterID"
         },
@@ -459,6 +462,11 @@
       "default": "",
       "description": "A comma-separated list of service accounts that are allowed to use node authentication for CSRs, e.g. \"istio-system/ztunnel\".",
       "type": "string"
+    },
+    "helm-values.app.server.certificateDuration": {
+      "default": 0,
+      "description": "Custom validity duration for a certificate.\nistio-csr will override a duration of the incoming gRPC CSR. Set to 0 to disable overriding (default behavior).",
+      "type": "number"
     },
     "helm-values.app.server.clusterID": {
       "default": "Kubernetes",

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -201,6 +201,10 @@ app:
     # the incoming gRPC CSR.
     # Based on [NIST 800-204A recommendations (SM-DR13)](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf).
     maxCertificateDuration: 1h
+    # Custom validity duration for a certificate.
+    # istio-csr will override a duration of the incoming gRPC CSR.
+    # Set to 0 to disable overriding (default behavior).
+    certificateDuration: 0
     serving:
       # Container address to serve the istio-csr gRPC service.
       address: 0.0.0.0

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -64,6 +64,8 @@ type Options struct {
 	// this value, this value will be used instead.
 	MaximumClientCertificateDuration time.Duration
 
+	ClientCertificateDuration time.Duration
+
 	// Authenticators configures authenticators to use for incoming CSR requests.
 	Authenticators AuthenticatorOptions
 
@@ -211,6 +213,14 @@ func (s *Server) CreateCertificate(ctx context.Context, icr *securityapi.IstioCe
 	if duration > s.opts.MaximumClientCertificateDuration {
 		duration = s.opts.MaximumClientCertificateDuration
 	}
+
+	// If custom client duration is specified, override with the value.
+
+	if s.opts.ClientCertificateDuration > 0 {
+		duration = s.opts.ClientCertificateDuration
+	}
+
+	log.V(2).Info("Setting certificate duration", "duration", duration)
 
 	bundle, err := s.cm.Sign(ctx, identities, []byte(icr.GetCsr()), duration, []cmapi.KeyUsage{cmapi.UsageClientAuth, cmapi.UsageServerAuth})
 	if err != nil {


### PR DESCRIPTION
Add app.server.certificateDuration

In our service mesh, we aim to increase the certificate duration beyond 24 hours. I noticed a similar request in https://github.com/cert-manager/istio-csr/issues/176