### PR TITLE
Bug Fix: istio-csr fails to load a trust bundle file due to a size limitation in cert-manager pki.DecodeX509CertificateChainBytes function

### DIFF
--- a/pkg/tls/rootca/rootca.go
+++ b/pkg/tls/rootca/rootca.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/fsnotify/fsnotify"
 	"github.com/go-logr/logr"
 )
@@ -152,14 +151,9 @@ func (w *watcher) loadRootCAsFile() (bool, RootCAs, error) {
 
 	w.log.Info("updating root CAs from file")
 
-	rootCAsCerts, err := pki.DecodeX509CertificateChainBytes(rootCAsPEM)
-	if err != nil {
-		return false, RootCAs{}, fmt.Errorf("failed to decode root CAs in certificate file %q: %w", w.filepath, err)
-	}
-
 	rootCAsPool := x509.NewCertPool()
-	for _, rootCert := range rootCAsCerts {
-		rootCAsPool.AddCert(rootCert)
+	if !rootCAsPool.AppendCertsFromPEM(rootCAsPEM) {
+		return false, RootCAs{}, fmt.Errorf("failed to decode root CAs in certificate file %q", w.filepath)
 	}
 
 	return true, RootCAs{rootCAsPEM, rootCAsPool}, nil


### PR DESCRIPTION
In a [slack discussion](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1733440158060159) @7ing reported that [the new size limit](https://github.com/cert-manager/cert-manager/pull/7400) for `DecodeX509CertificateChainBytes` was too small for istio-csr to decode a trust store (such as a publicly trusted cert bundle).

Instead, we can use the built in [AppendCertsFromPEM ](https://pkg.go.dev/crypto/x509#CertPool.AppendCertsFromPEM) function.

The new unit test in this PR demonstrates the problem:
 * https://prow.infra.cert-manager.io/view/gs/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_istio-csr/475/pull-cert-manager-istio-csr-unit/1875246131970052096
 
```
github.com/cert-manager/istio-csr/pkg/tls/rootca: TestLoadRootCAsFile_SystemCertPool 

{Failed  === RUN   TestLoadRootCAsFile_SystemCertPool
    rootca.go:153: I0103 18:23:08.403362] updating root CAs from file
    rootca_test.go:167: 
        	Error Trace:	/home/prow/go/src/github.com/cert-manager/istio-csr/pkg/tls/rootca/rootca_test.go:167
        	Error:      	Received unexpected error:
        	            	failed to decode root CAs in certificate file "/etc/ssl/certs/ca-certificates.crt": provided PEM data was larger than the maximum 65000B
        	Test:       	TestLoadRootCAsFile_SystemCertPool
        	Messages:   	Should have loaded the system CA certificate pool
    rootca_test.go:168: 
        	Error Trace:	/home/prow/go/src/github.com/cert-manager/istio-csr/pkg/tls/rootca/rootca_test.go:168
        	Error:      	Should be true
        	Test:       	TestLoadRootCAsFile_SystemCertPool
--- FAIL: TestLoadRootCAsFile_SystemCertPool (0.00s)
}
```

