### PR TITLE
Use an alpha version of cert-manager to ensure fixed code is used

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.23.0
 replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
 
 require (
-	github.com/cert-manager/cert-manager v1.16.0-beta.0.0.20250107112437-c422d5944196
+	github.com/cert-manager/cert-manager v1.17.0-alpha.0
 	github.com/fsnotify/fsnotify v1.8.0
 	github.com/go-logr/logr v1.4.2
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyY
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.4.1 h1:iKLQ0xPNFxR/2hzXZMrBo8f1j86j5WHzznCCQxV/b8g=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=
-github.com/cert-manager/cert-manager v1.16.0-beta.0.0.20250107112437-c422d5944196 h1:RQPtJs8AojaT5d4ftqFdUsOYIzKja7DahMaMTyyfdFY=
-github.com/cert-manager/cert-manager v1.16.0-beta.0.0.20250107112437-c422d5944196/go.mod h1:yrW1ShuyHwr544VTlqSrIfMJgmaF1YTTOKXsPQjbm2U=
+github.com/cert-manager/cert-manager v1.17.0-alpha.0 h1:wE3nujch/q+FWpew7vcihBa55qfgVk8EFDWlyPZmyWE=
+github.com/cert-manager/cert-manager v1.17.0-alpha.0/go.mod h1:zeG4D+AdzqA7hFMNpYCJgcQ2VOfFNBa+Jzm3kAwiDU4=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=


### PR DESCRIPTION
See https://github.com/cert-manager/istio-csr/pull/479#issuecomment-2587228710 for justification of this.

This should fix the failing govulncheck job, and prevent dependabot from trying to "upgrade" the cert-manager version to a broken version (which it's doing because it sees that 1.16.x is newer than v1.16.beta.0 - it doesn't see that we haven't backported [a fix](https://github.com/cert-manager/cert-manager/pull/7464) from master into the release-1.16 branch)