### PR TITLE
Add `PodDisruptionBudget` to helm chart

### DIFF
--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -604,5 +604,12 @@ extraObjects:
     metadata:
       name: '{{ template "cert-manager-istio-csr.fullname" . }}-extra-configmap'
 ```
+#### **podDisruptionBudget** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Configures a disruption budget for istio-csr.
 
 <!-- /AUTO-GENERATED -->

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -611,13 +611,13 @@ extraObjects:
 > ```
 
 Enable or disable the PodDisruptionBudget resource for istio-csr.
-#### **podDisruptionBudget.minAvailable** ~ `unknown`
+#### **podDisruptionBudget.minAvailable** ~ `string,integer`
 
 This configures the minimum available pods for disruptions. It can either be set to an integer (e.g., 1) or a percentage value (e.g., 25%).  
 It cannot be used if `maxUnavailable` is set.
 
 
-#### **podDisruptionBudget.maxUnavailable** ~ `unknown`
+#### **podDisruptionBudget.maxUnavailable** ~ `string,integer`
 > Default value:
 > ```yaml
 > 1

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -612,10 +612,6 @@ extraObjects:
 
 Enable or disable the PodDisruptionBudget resource for istio-csr.
 #### **podDisruptionBudget.minAvailable** ~ `unknown`
-> Default value:
-> ```yaml
-> 1
-> ```
 
 This configures the minimum available pods for disruptions. It can either be set to an integer (e.g., 1) or a percentage value (e.g., 25%).  
 It cannot be used if `maxUnavailable` is set.
@@ -624,7 +620,7 @@ It cannot be used if `maxUnavailable` is set.
 #### **podDisruptionBudget.maxUnavailable** ~ `unknown`
 > Default value:
 > ```yaml
-> null
+> 1
 > ```
 
 This configures the maximum unavailable pods for disruptions. It can either be set to an integer (e.g., 1) or a percentage value (e.g., 25%). it cannot be used if `minAvailable` is set.

--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -604,12 +604,31 @@ extraObjects:
     metadata:
       name: '{{ template "cert-manager-istio-csr.fullname" . }}-extra-configmap'
 ```
-#### **podDisruptionBudget** ~ `object`
+#### **podDisruptionBudget.enabled** ~ `bool`
 > Default value:
 > ```yaml
-> {}
+> false
 > ```
 
-Configures a disruption budget for istio-csr.
+Enable or disable the PodDisruptionBudget resource for istio-csr.
+#### **podDisruptionBudget.minAvailable** ~ `unknown`
+> Default value:
+> ```yaml
+> 1
+> ```
+
+This configures the minimum available pods for disruptions. It can either be set to an integer (e.g., 1) or a percentage value (e.g., 25%).  
+It cannot be used if `maxUnavailable` is set.
+
+
+#### **podDisruptionBudget.maxUnavailable** ~ `unknown`
+> Default value:
+> ```yaml
+> null
+> ```
+
+This configures the maximum unavailable pods for disruptions. It can either be set to an integer (e.g., 1) or a percentage value (e.g., 25%). it cannot be used if `minAvailable` is set.
+
+
 
 <!-- /AUTO-GENERATED -->

--- a/deploy/charts/istio-csr/templates/poddisruptionbudget.yaml
+++ b/deploy/charts/istio-csr/templates/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    {{- include "cert-manager-istio-csr.labels" . | nindent 4 }}
+  name: {{ include "cert-manager-istio-csr.name" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "cert-manager-istio-csr.name" . }}
+  {{- with .Values.podDisruptionBudget }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/deploy/charts/istio-csr/templates/poddisruptionbudget.yaml
+++ b/deploy/charts/istio-csr/templates/poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podDisruptionBudget }}
+{{- if .Values.podDisruptionBudget.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -10,7 +10,10 @@ spec:
   selector:
     matchLabels:
       app: {{ include "cert-manager-istio-csr.name" . }}
-  {{- with .Values.podDisruptionBudget }}
-    {{- toYaml . | nindent 2 }}
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
   {{- end }}
 {{- end }}

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -710,10 +710,10 @@
       "type": "boolean"
     },
     "helm-values.podDisruptionBudget.maxUnavailable": {
+      "default": 1,
       "description": "This configures the maximum unavailable pods for disruptions. It can either be set to an integer (e.g., 1) or a percentage value (e.g., 25%). it cannot be used if `minAvailable` is set."
     },
     "helm-values.podDisruptionBudget.minAvailable": {
-      "default": 1,
       "description": "This configures the minimum available pods for disruptions. It can either be set to an integer (e.g., 1) or a percentage value (e.g., 25%).\nIt cannot be used if `maxUnavailable` is set."
     },
     "helm-values.podLabels": {

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -690,9 +690,31 @@
       "type": "object"
     },
     "helm-values.podDisruptionBudget": {
-      "default": {},
-      "description": "Configures a disruption budget for istio-csr.",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "$ref": "#/$defs/helm-values.podDisruptionBudget.enabled"
+        },
+        "maxUnavailable": {
+          "$ref": "#/$defs/helm-values.podDisruptionBudget.maxUnavailable"
+        },
+        "minAvailable": {
+          "$ref": "#/$defs/helm-values.podDisruptionBudget.minAvailable"
+        }
+      },
       "type": "object"
+    },
+    "helm-values.podDisruptionBudget.enabled": {
+      "default": false,
+      "description": "Enable or disable the PodDisruptionBudget resource for istio-csr.",
+      "type": "boolean"
+    },
+    "helm-values.podDisruptionBudget.maxUnavailable": {
+      "description": "This configures the maximum unavailable pods for disruptions. It can either be set to an integer (e.g., 1) or a percentage value (e.g., 25%). it cannot be used if `minAvailable` is set."
+    },
+    "helm-values.podDisruptionBudget.minAvailable": {
+      "default": 1,
+      "description": "This configures the minimum available pods for disruptions. It can either be set to an integer (e.g., 1) or a percentage value (e.g., 25%).\nIt cannot be used if `maxUnavailable` is set."
     },
     "helm-values.podLabels": {
       "default": {},

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -39,6 +39,9 @@
         "podAnnotations": {
           "$ref": "#/$defs/helm-values.podAnnotations"
         },
+        "podDisruptionBudget": {
+          "$ref": "#/$defs/helm-values.podDisruptionBudget"
+        },
         "podLabels": {
           "$ref": "#/$defs/helm-values.podLabels"
         },
@@ -684,6 +687,26 @@
     "helm-values.podAnnotations": {
       "default": {},
       "description": "Optional extra annotations for pod.",
+      "type": "object"
+    },
+    "helm-values.podDisruptionBudget": {
+      "default": {},
+      "description": "PodDisruptionBudget configuration.",
+      "properties": {
+        "minAvailable": {
+          "description": "Minimum number of pods that must still be available after the eviction, even in the presence of a PodDisruptionBudget.",
+          "type": ["number", "string"]
+        },
+        "maxUnavailable": {
+          "description": "Maximum number of pods that can be unavailable during the eviction, even in the presence of a PodDisruptionBudget.",
+          "type": ["number", "string"]
+        },
+        "unhealthyPodEvictionPolicy": {
+          "description": "Policy for unhealthy pods. IfHealthyBudget will only evict pods if the budget is healthy. AlwaysAllow will always allow evictions.",
+          "type": "string",
+          "enum": ["", "IfHealthyBudget", "AlwaysAllow"]
+        }
+      },
       "type": "object"
     },
     "helm-values.podLabels": {

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -691,22 +691,7 @@
     },
     "helm-values.podDisruptionBudget": {
       "default": {},
-      "description": "PodDisruptionBudget configuration.",
-      "properties": {
-        "minAvailable": {
-          "description": "Minimum number of pods that must still be available after the eviction, even in the presence of a PodDisruptionBudget.",
-          "type": ["number", "string"]
-        },
-        "maxUnavailable": {
-          "description": "Maximum number of pods that can be unavailable during the eviction, even in the presence of a PodDisruptionBudget.",
-          "type": ["number", "string"]
-        },
-        "unhealthyPodEvictionPolicy": {
-          "description": "Policy for unhealthy pods. IfHealthyBudget will only evict pods if the budget is healthy. AlwaysAllow will always allow evictions.",
-          "type": "string",
-          "enum": ["", "IfHealthyBudget", "AlwaysAllow"]
-        }
-      },
+      "description": "Configures a disruption budget for istio-csr.",
       "type": "object"
     },
     "helm-values.podLabels": {

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -360,13 +360,20 @@ commonLabels: {}
 extraObjects: []
 
 # Configures a disruption budget for istio-csr.
-podDisruptionBudget: {}
-# For example:
-#
-# podDisruptionBudget:
-#   minAvailable: 1
-#
-# Or
-#
-# podDisruptionBudget:
-#   maxUnavailable: 0
+podDisruptionBudget:
+  # Enable or disable the PodDisruptionBudget resource for istio-csr.
+  enabled: false
+
+  # This configures the minimum available pods for disruptions. It can either be set to
+  # an integer (e.g., 1) or a percentage value (e.g., 25%).
+  # It cannot be used if `maxUnavailable` is set.
+  # +docs:property
+  # +docs:type=unknown
+  minAvailable: 1
+
+  # This configures the maximum unavailable pods for disruptions. It can either be set to
+  # an integer (e.g., 1) or a percentage value (e.g., 25%).
+  # it cannot be used if `minAvailable` is set.
+  # +docs:property
+  # +docs:type=unknown
+  maxUnavailable:

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -358,3 +358,15 @@ commonLabels: {}
 #     metadata:
 #       name: '{{ template "cert-manager-istio-csr.fullname" . }}-extra-configmap'
 extraObjects: []
+
+# Configures a disruption budget for istio-csr.
+podDisruptionBudget: {}
+# For example:
+#
+# podDisruptionBudget:
+#   minAvailable: 1
+#
+# Or
+#
+# podDisruptionBudget:
+#   maxUnavailable: 0

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -368,12 +368,12 @@ podDisruptionBudget:
   # an integer (e.g., 1) or a percentage value (e.g., 25%).
   # It cannot be used if `maxUnavailable` is set.
   # +docs:property
-  # +docs:type=unknown
+  # +docs:type=string,integer
   # minAvailable: 0
 
   # This configures the maximum unavailable pods for disruptions. It can either be set to
   # an integer (e.g., 1) or a percentage value (e.g., 25%).
   # it cannot be used if `minAvailable` is set.
   # +docs:property
-  # +docs:type=unknown
+  # +docs:type=string,integer
   maxUnavailable: 1

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -369,11 +369,11 @@ podDisruptionBudget:
   # It cannot be used if `maxUnavailable` is set.
   # +docs:property
   # +docs:type=unknown
-  minAvailable: 1
+  # minAvailable: 0
 
   # This configures the maximum unavailable pods for disruptions. It can either be set to
   # an integer (e.g., 1) or a percentage value (e.g., 25%).
   # it cannot be used if `minAvailable` is set.
   # +docs:property
   # +docs:type=unknown
-  maxUnavailable:
+  maxUnavailable: 1


### PR DESCRIPTION
- fixed #516

- Add `PodDisruptionBudget` to helm chart