### PR TITLE
fix: make handling of additionalAnnotations more robust:Jason Howard …

### DIFF
--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -228,6 +228,9 @@ Takes key/value pairs in the format:
 additionalAnnotations:
   - name: custom.cert-manager.io/policy-name
     value: istio-csr
+  - name: venafi.cert-manager.io/custom-fields
+    value: |
+      [{ "Name": "field1", "Value": "value1" },{ "Name": "field2", "Value": "value2" }]
 ```
 #### **app.certmanager.issuer.enabled** ~ `bool`
 > Default value:

--- a/deploy/charts/istio-csr/templates/certificate.yaml
+++ b/deploy/charts/istio-csr/templates/certificate.yaml
@@ -16,7 +16,8 @@ metadata:
 {{- if .Values.app.certmanager.additionalAnnotations }}
   annotations:
     {{- range $annotation := .Values.app.certmanager.additionalAnnotations }}
-    {{ $annotation.name }}: {{ $annotation.value }}
+    {{ $annotation.name }}: |
+{{ $annotation.value | indent 6 }}
     {{- end }}
 {{- end }}
 spec:

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -86,7 +86,7 @@ spec:
               {{- $x := list $annotation.name $annotation.value | join "=" }}
               {{- $annotations = append $annotations $x }}
             {{- end }}
-          - "--certificate-request-additional-annotations={{ join "," $annotations }}"
+          - {{ printf "%s=%s" "--certificate-request-additional-annotations" ( join "," $annotations ) | quote -}}
           {{- end }}
 
             # tls
@@ -135,7 +135,7 @@ spec:
           {{- range $annotation := .Values.app.certmanager.additionalAnnotations }}
           {{ $annotationList = append $annotationList (printf "%s=%s" $annotation.name $annotation.value) }}
           {{- end }}
-          - "--istiod-cert-additional-annotations={{ join "," $annotationList }}"
+          - {{ printf "%s=%s" "--istiod-cert-additional-annotations" ( join "," $annotationList ) | quote -}}
           {{- end }}
           - "--istiod-cert-istio-revisions={{ join "," .Values.app.istio.revisions }}"
         {{- if .Values.volumeMounts }}


### PR DESCRIPTION
…<jayhow@gmail.com>


The helm chart  interprets more complex additionalAnnotation incorrectly and will not render charts.

See linked issue for more detail:

https://github.com/cert-manager/istio-csr/issues/534

In summary this PR ensures annotation values passed to the csr agent are safe and ensures bootstrap Certificate annotation values are interpreted as a string.