### PR TITLE
Fix new noctx linter violations

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -164,7 +164,8 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 
 	// listen on the configured address
-	listener, err := net.Listen("tcp", s.opts.ServingAddress)
+	lc := net.ListenConfig{}
+	listener, err := lc.Listen(ctx, "tcp", s.opts.ServingAddress)
 	if err != nil {
 		return fmt.Errorf("failed to listen %s: %v", s.opts.ServingAddress, err)
 	}

--- a/test/e2e-pure-runtime/suite/suite.go
+++ b/test/e2e-pure-runtime/suite/suite.go
@@ -159,7 +159,7 @@ func kubectlWithOutput(f *framework.Framework, args ...string) (string, error) {
 	buf := &bytes.Buffer{}
 
 	// #nosec G204
-	cmd := exec.Command(f.Config().KubectlPath, args...)
+	cmd := exec.CommandContext(f.Context(), f.Config().KubectlPath, args...)
 
 	cmd.Stdout = buf
 	cmd.Stderr = GinkgoWriter
@@ -183,7 +183,7 @@ func istioctlGetCert(f *framework.Framework, podName string, namespaceName strin
 	buf := &bytes.Buffer{}
 
 	// #nosec G204
-	cmd := exec.Command(f.Config().IstioctlPath, "proxy-config", "secrets", "-n", namespaceName, podName, "-ojson")
+	cmd := exec.CommandContext(f.Context(), f.Config().IstioctlPath, "proxy-config", "secrets", "-n", namespaceName, podName, "-ojson")
 
 	cmd.Stdout = buf
 	cmd.Stderr = GinkgoWriter

--- a/test/e2e/suite/runtimeconfiguration/runtimeconfiguration.go
+++ b/test/e2e/suite/runtimeconfiguration/runtimeconfiguration.go
@@ -183,7 +183,7 @@ func kubectlWithOutput(f *framework.Framework, args ...string) (string, error) {
 	buf := &bytes.Buffer{}
 
 	// #nosec G204
-	cmd := exec.Command(f.Config().KubectlPath, args...)
+	cmd := exec.CommandContext(f.Context(), f.Config().KubectlPath, args...)
 
 	cmd.Stdout = buf
 	cmd.Stderr = GinkgoWriter
@@ -226,10 +226,10 @@ func istioctlGetCert(f *framework.Framework, podName string, namespaceName strin
 	cmd := func() *exec.Cmd {
 		if f.Config().AmbientEnabled {
 			// #nosec G204
-			return exec.Command(f.Config().IstioctlPath, "experimental", "ztunnel-config", "certificates", "-n", namespaceName, "-ojson")
+			return exec.CommandContext(f.Context(), f.Config().IstioctlPath, "experimental", "ztunnel-config", "certificates", "-n", namespaceName, "-ojson")
 		} else {
 			// #nosec G204
-			return exec.Command(f.Config().IstioctlPath, "proxy-config", "secrets", "-n", namespaceName, podName, "-ojson")
+			return exec.CommandContext(f.Context(), f.Config().IstioctlPath, "proxy-config", "secrets", "-n", namespaceName, podName, "-ojson")
 		}
 	}()
 


### PR DESCRIPTION
This PR is to ensure that https://github.com/cert-manager/istio-csr/pull/584 will succeed in CI. The golangci-lint upgrade requires some code to be made more context-aware.

Framework updates are based on equivalent code copied from https://github.com/cert-manager/csi-driver-spiffe.