### PR TITLE
Ungroup istio.io/api in Renovate for now

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,4 +3,13 @@
   extends: [
     'github>cert-manager/renovate-config:default.json5',
   ],
+  packageRules: [
+    {
+      // FIXME: Ungroup istio.io/api for now, since we currently depend on a pseudo-version that Renovate doesn't understand.
+      groupName: null,
+      matchPackageNames: [
+        'istio.io/api',
+      ],
+    }
+  ],
 }


### PR DESCRIPTION
To mend https://github.com/cert-manager/istio-csr/pull/641. It can hopefully be reverted when Istio API 1.28 is released.

Similar to what we did here: https://github.com/cert-manager/cmctl/blob/ead5804eb0af3075eadd7e8196a4d76e0d722984/.github/renovate.json5#L6C3-L14C5

/cc @ThatsMrTalbot 