### PR TITLE
Fix HasIssuerConfig to use RLock instead of Lock

### DIFF
--- a/pkg/certmanager/certmanager.go
+++ b/pkg/certmanager/certmanager.go
@@ -546,8 +546,8 @@ func (m *manager) WaitForIssuerConfig(ctx context.Context) {
 }
 
 func (m *manager) HasIssuerConfig() bool {
-	m.activeIssuerRefMutex.Lock()
-	defer m.activeIssuerRefMutex.Unlock()
+	m.activeIssuerRefMutex.RLock()
+	defer m.activeIssuerRefMutex.RUnlock()
 
 	return m.activeIssuerRef != nil
 }


### PR DESCRIPTION
HasIssuerConfig only reads activeIssuerRef but acquires a write lock, unnecessarily blocking concurrent Sign calls.