### PR TITLE
Bump Istio version used in e2e-tests

### DIFF
--- a/make/test-e2e.mk
+++ b/make/test-e2e.mk
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ISTIO_VERSION ?= 1.23.2
+ISTIO_VERSION ?= 1.29.3
 ISTIO_CONFIG_FILE ?= ./make/config/istio/istio-config-default.yaml
 
 .PHONY: print-latest-istio-version


### PR DESCRIPTION
I noticed that we're using an old and unsupported Istio version when trying to debug https://github.com/cert-manager/istio-csr/pull/810. We should ideally configure Renovate to bump this, but I am leaving this for a follow-up PR.