### PR TITLE
feat(chart): expose priorityClassName in the istio-csr chart

### DIFF
--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -542,6 +542,13 @@ resources:
     cpu: 100m
     memory: 128Mi
 ```
+#### **priorityClassName** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
+
+Configure the priority class of the pod. For more information, see [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass).
 #### **securityContext** ~ `object`
 > Default value:
 > ```yaml

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "cert-manager-istio-csr.name" . }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: "{{ . }}"
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -51,6 +51,9 @@
         "podLabels": {
           "$ref": "#/$defs/helm-values.podLabels"
         },
+        "priorityClassName": {
+          "$ref": "#/$defs/helm-values.priorityClassName"
+        },
         "replicaCount": {
           "$ref": "#/$defs/helm-values.replicaCount"
         },
@@ -751,6 +754,11 @@
       "default": {},
       "description": "Optional extra labels for pod.",
       "type": "object"
+    },
+    "helm-values.priorityClassName": {
+      "default": "",
+      "description": "Configure the priority class of the pod. For more information, see [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass).",
+      "type": "string"
     },
     "helm-values.replicaCount": {
       "default": 1,

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -324,6 +324,9 @@ volumeMounts: []
 #      memory: 128Mi
 resources: {}
 
+# Configure the priority class of the pod. For more information, see [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass).
+priorityClassName: ""
+
 # Kubernetes [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 #
 # See the default values for an example.


### PR DESCRIPTION
## What

Exposes a `priorityClassName` value in the istio-csr Helm chart and wires it into the Deployment.

## Why

Every other cert-manager chart already lets operators set a `priorityClassName` on the workload (cert-manager, trust-manager, approver-policy, csi-driver, csi-driver-spiffe, google-cas-issuer), using the same value, comment and template idiom. istio-csr was the only one missing it, so operators who rely on PriorityClasses to protect this control-plane component from preemption had to fork the chart.

This adds the value with the exact same wording and `{{- with .Values.priorityClassName }}` idiom as the sibling charts.

## Behaviour

Default is `""`, so the rendered Deployment is unchanged. Verified:
- `helm template` default → no `priorityClassName` rendered.
- `helm template --set priorityClassName=system-cluster-critical` → renders correctly.
- `values.schema.json` and `README.md` regenerated via `make generate-helm-schema generate-helm-docs`.
- `make verify-helm-values`, `verify-helm-lint`, `verify-helm-unittest` pass.

```release-note
The istio-csr Helm chart now supports setting `priorityClassName` on the deployment.
```
