### PR TITLE
fix(istio-csr): gate ServiceMonitor on metrics service being enabled

### DIFF
--- a/deploy/charts/istio-csr/templates/metrics-servicemonitor.yaml
+++ b/deploy/charts/istio-csr/templates/metrics-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.app.metrics.service.servicemonitor.enabled }}
+{{- if and .Values.app.metrics.service.enabled .Values.app.metrics.service.servicemonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
## What

Gate the istio-csr `ServiceMonitor` on **both** `app.metrics.service.enabled` and `app.metrics.service.servicemonitor.enabled`, instead of only the latter.

## Why

Currently `metrics-servicemonitor.yaml` renders whenever `servicemonitor.enabled` is true, ignoring whether the metrics `Service` exists. If an operator disables the metrics Service but leaves the ServiceMonitor enabled, the chart emits an **orphan ServiceMonitor** — a scrape target pointing at a Service that was never created.

istio-csr is the only cert-manager chart missing this guard — `trust-manager`, `approver-policy` and `csi-driver-spiffe` all gate their ServiceMonitor on `and ...service.enabled ...servicemonitor.enabled`. This brings istio-csr in line.

## Verification

- Default (`servicemonitor.enabled=false`) → 0 ServiceMonitors (unchanged).
- `--set app.metrics.service.servicemonitor.enabled=true` → 1 (unchanged behaviour).
- `--set app.metrics.service.enabled=false --set app.metrics.service.servicemonitor.enabled=true` → **0** (was 1 orphan).
- `helm lint` passes; template-only change.

```release-note
The istio-csr ServiceMonitor is no longer rendered when the metrics Service is disabled.
```
