### PR TITLE
feat(chart): expose automountServiceAccountToken in the istio-csr chart

### DIFF
--- a/deploy/charts/istio-csr/README.md
+++ b/deploy/charts/istio-csr/README.md
@@ -492,6 +492,14 @@ Optional extra labels for pod.
 > ```
 
 Optional extra annotations for pod.
+#### **automountServiceAccountToken** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Automounting API credentials for the istio-csr pod.
+
 #### **volumes** ~ `array`
 > Default value:
 > ```yaml

--- a/deploy/charts/istio-csr/templates/deployment.yaml
+++ b/deploy/charts/istio-csr/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "cert-manager-istio-csr.name" . }}
+      {{- if hasKey .Values "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- end }}
       {{- with .Values.priorityClassName }}
       priorityClassName: "{{ . }}"
       {{- end }}

--- a/deploy/charts/istio-csr/values.schema.json
+++ b/deploy/charts/istio-csr/values.schema.json
@@ -9,6 +9,9 @@
         "app": {
           "$ref": "#/$defs/helm-values.app"
         },
+        "automountServiceAccountToken": {
+          "$ref": "#/$defs/helm-values.automountServiceAccountToken"
+        },
         "commonLabels": {
           "$ref": "#/$defs/helm-values.commonLabels"
         },
@@ -615,6 +618,11 @@
       "default": "cluster.local",
       "description": "The Istio cluster's trust domain.",
       "type": "string"
+    },
+    "helm-values.automountServiceAccountToken": {
+      "default": true,
+      "description": "Automounting API credentials for the istio-csr pod.",
+      "type": "boolean"
     },
     "helm-values.commonLabels": {
       "default": {},

--- a/deploy/charts/istio-csr/values.yaml
+++ b/deploy/charts/istio-csr/values.yaml
@@ -295,6 +295,10 @@ podLabels: {}
 # Optional extra annotations for pod.
 podAnnotations: {}
 
+# Automounting API credentials for the istio-csr pod.
+# +docs:property
+automountServiceAccountToken: true
+
 # Optional extra volumes. Useful for mounting custom root CAs.
 #
 # For example:


### PR DESCRIPTION
## What
Adds an `automountServiceAccountToken` value to the istio-csr chart so operators can disable automatic mounting of the ServiceAccount token on the istio-csr pod.

This matches the option already available in the [trust-manager chart](https://github.com/cert-manager/trust-manager) and is a common security-hardening request.

## Details
- New `automountServiceAccountToken` value (defaults to `true`, preserving current behaviour).
- Rendered on the pod spec via `{{- if hasKey .Values "automountServiceAccountToken" }}`.
- Regenerated `values.schema.json` and `README.md` with `helm-tool`.

`helm lint` passes; `helm template --set automountServiceAccountToken=false` renders `automountServiceAccountToken: false` on the Deployment pod spec.