### PR TITLE
Adopt proposed helm-diff target from makefile-modules PR 470

### DIFF
--- a/klone.yaml
+++ b/klone.yaml
@@ -33,9 +33,9 @@ targets:
       repo_hash: b514cb5c3841a7877b5f44c070b5097d98347562
       repo_path: modules/go
     - folder_name: helm
-      repo_url: https://github.com/cert-manager/makefile-modules.git
-      repo_ref: main
-      repo_hash: b514cb5c3841a7877b5f44c070b5097d98347562
+      repo_url: https://github.com/hjoshi123/makefile-modules.git
+      repo_ref: feat/helm-diff-target
+      repo_hash: f9a8ff07dfd31c001f44b668ba001afc88a5bcb1
       repo_path: modules/helm
     - folder_name: help
       repo_url: https://github.com/cert-manager/makefile-modules.git

--- a/make/_shared/helm/helm.mk
+++ b/make/_shared/helm/helm.mk
@@ -44,6 +44,8 @@ helm_chart_sources := $(shell find $(helm_chart_source_dir) -maxdepth 1 -type f)
 helm_chart_archive := $(bin_dir)/scratch/helm/$(helm_chart_name)-$(helm_chart_version).tgz
 helm_digest_path := $(bin_dir)/scratch/helm/$(helm_chart_name)-$(helm_chart_version).digests
 helm_digest = $(shell head -1 $(helm_digest_path) 2> /dev/null)
+HELM_IGNORE_FIELDS ?= ^Pulled:|^Digest:|app.kubernetes.io/version|helm.sh/chart|chart:|appVersion:|managed-by:|meta.helm.sh/release-namespace
+helm_chart_old_version ?=
 
 $(bin_dir)/scratch/helm:
 	@mkdir -p $@
@@ -114,14 +116,6 @@ verify-helm-values: | $(NEEDS_HELM-TOOL) $(NEEDS_GOJQ)
 	$(HELM-TOOL) lint -i $(helm_chart_source_dir)/values.yaml -d $(helm_chart_source_dir)/templates -e $(helm_chart_source_dir)/values.linter.exceptions
 
 shared_verify_targets += verify-helm-values
-
-.PHONY: verify-helm-unittest
-## Run Helm chart unit tests using helm-unittest.
-## @category [shared] Generate/ Verify
-verify-helm-unittest: | $(NEEDS_HELM-UNITTEST)
-	$(HELM-UNITTEST) -f 'tests/**/*.yaml' $(helm_chart_source_dir)
-
-shared_verify_targets += verify-helm-unittest
 
 $(bin_dir)/scratch/kyverno:
 	@mkdir -p $@
@@ -195,3 +189,19 @@ verify-helm-kubeconform: $(helm_chart_archive) | $(NEEDS_KUBECONFORM)
 		-strict
 
 shared_verify_targets_dirty += verify-helm-kubeconform
+
+## Diff the locally built Helm chart against a released version,
+## ignoring version-label noise. Set helm_chart_old_version to the
+## previously released chart version to compare against.
+## @category [shared] Helm Chart
+.PHONY: helm-diff
+helm-diff: $(helm_chart_archive) | $(NEEDS_HELM)
+	@if [ -z "$(helm_chart_old_version)" ]; then \
+		echo "Usage: make helm-diff helm_chart_old_version=<version>"; \
+		exit 1; \
+	fi
+	@$(HELM) show chart "oci://$(helm_chart_image_registry)$(helm_chart_name)" --version "$(helm_chart_old_version)" > /dev/null
+	@diff -u \
+		<($(HELM) template "oci://$(helm_chart_image_registry)$(helm_chart_name)" --version "$(helm_chart_old_version)" $(INSTALL_OPTIONS) | grep -vE -- '$(HELM_IGNORE_FIELDS)') \
+		<($(HELM) template "$(helm_chart_archive)" $(INSTALL_OPTIONS) | grep -vE -- '$(HELM_IGNORE_FIELDS)') \
+		|| [ $$? -eq 1 ]


### PR DESCRIPTION
Adopt the `helm-diff` target proposed in cert-manager/makefile-modules#470, by pinning the `helm` klone module to the fork branch (`hjoshi123/makefile-modules@feat/helm-diff-target`, commit `f9a8ff0`).

The target diffs the locally built chart against a previously released chart version, filtering out version-label noise. I verified it against the v0.17.0 release.

With default values it shows only the image tag change (the template changes in v0.17.0 are all behind values flags):

```console
$ make helm-diff helm_chart_old_version=v0.16.0
make: Entering directory '/home/richard/projects/github.com/cert-manager/istio-csr/.claude/worktrees/istio-csr-release'
[info]: downloaded /home/richard/.cache/makefile-modules/downloaded/tools/helm@v4.2.3_linux_amd64
rm -rf _bin/scratch/helm/cert-manager-istio-csr-v0.17.0-dirty.tgz.tmp
mkdir -p _bin/scratch/helm/
cp -a deploy/charts/istio-csr _bin/scratch/helm/cert-manager-istio-csr-v0.17.0-dirty.tgz.tmp
echo "no mutations defined for this chart"
no mutations defined for this chart
/home/richard/projects/github.com/cert-manager/istio-csr/.claude/worktrees/istio-csr-release/_bin/tools/yq '.annotations."artifacthub.io/prerelease" = "false"' \
	--inplace _bin/scratch/helm/cert-manager-istio-csr-v0.17.0-dirty.tgz.tmp/Chart.yaml
mkdir -p _bin/scratch/helm/
/home/richard/projects/github.com/cert-manager/istio-csr/.claude/worktrees/istio-csr-release/_bin/tools/helm package _bin/scratch/helm/cert-manager-istio-csr-v0.17.0-dirty.tgz.tmp \
	--app-version v0.17.0-dirty \
	--version v0.17.0-dirty \
	--destination _bin/scratch/helm/
Successfully packaged chart and saved it to: _bin/scratch/helm/cert-manager-istio-csr-v0.17.0-dirty.tgz
--- /dev/fd/63	2026-08-14 15:40:18.703105868 +0100
+++ /dev/fd/62	2026-08-14 15:40:18.703105868 +0100
@@ -237,7 +237,7 @@
         kubernetes.io/os: linux
       containers:
       - name: cert-manager-istio-csr
-        image: "cert-manager.local/cert-manager-istio-csr:v0.16.0"
+        image: "cert-manager.local/cert-manager-istio-csr:v0.17.0-dirty"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6443
make: Leaving directory '/home/richard/projects/github.com/cert-manager/istio-csr/.claude/worktrees/istio-csr-release'
```

And with the values from #835 it correctly shows the ServiceMonitor gating fix — v0.16.0 renders the ServiceMonitor even when the metrics Service is disabled, v0.17.0 does not:

```console
$ make helm-diff helm_chart_old_version=v0.16.0 \
    INSTALL_OPTIONS="--set app.metrics.service.enabled=false --set app.metrics.service.servicemonitor.enabled=true"
make: Entering directory '/home/richard/projects/github.com/cert-manager/istio-csr/.claude/worktrees/istio-csr-release'
--- /dev/fd/63	2026-08-14 15:40:55.383757849 +0100
+++ /dev/fd/62	2026-08-14 15:40:55.383757849 +0100
@@ -211,7 +211,7 @@
         kubernetes.io/os: linux
       containers:
       - name: cert-manager-istio-csr
-        image: "quay.io/jetstack/cert-manager-istio-csr:v0.16.0"
+        image: "quay.io/jetstack/cert-manager-istio-csr:v0.17.0-dirty"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6443
@@ -320,29 +320,3 @@
     name: istio-ca
     kind: Issuer
     group: cert-manager.io
-
----
-# Source: cert-manager-istio-csr/templates/metrics-servicemonitor.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: cert-manager-istio-csr
-  namespace: default
-  labels:
-    app: cert-manager-istio-csr
-    app.kubernetes.io/name: cert-manager-istio-csr
-    app.kubernetes.io/instance: release-name
-    prometheus: default
-spec:
-  jobLabel: cert-manager-istio-csr
-  selector:
-    matchLabels:
-      app: cert-manager-istio-csr-metrics
-  namespaceSelector:
-    matchNames:
-      - default
-  endpoints:
-  - targetPort: 9402
-    path: "/metrics"
-    interval: 10s
-    scrapeTimeout: 5s
make: Leaving directory '/home/richard/projects/github.com/cert-manager/istio-csr/.claude/worktrees/istio-csr-release'
```

Holding until cert-manager/makefile-modules#470 merges; then repoint the `helm` module at upstream `main` and regenerate.

*with claude fable-5*
