### PR TITLE
fix(istiodcert): name the DNS name that failed validation

### DIFF
--- a/pkg/istiodcert/options.go
+++ b/pkg/istiodcert/options.go
@@ -108,7 +108,7 @@ func (o *Options) Validate() error {
 			// This validation function returns a slice of strings if there was an error
 			validationErrors := k8svalidation.IsDNS1123Subdomain(name)
 			if len(validationErrors) > 0 {
-				errs = append(errs, fmt.Errorf("invalid additional DNS name %q: ", strings.Join(validationErrors, ", ")))
+				errs = append(errs, fmt.Errorf("invalid additional DNS name %q: %s", name, strings.Join(validationErrors, ", ")))
 			}
 		}
 	}

--- a/pkg/istiodcert/options_test.go
+++ b/pkg/istiodcert/options_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package istiodcert
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+)
+
+// validOptions returns options which Validate accepts, so each test case only
+// has to state the field it is exercising.
+func validOptions() Options {
+	return Options{
+		Enabled:                 true,
+		Duration:                time.Hour,
+		RenewBefore:             30 * time.Minute,
+		KeyAlgorithm:            "RSA",
+		KeySize:                 minRSAKeySize,
+		MaxConcurrentReconciles: 1,
+	}
+}
+
+func TestOptionsValidate(t *testing.T) {
+	tests := map[string]struct {
+		mutate      func(*Options)
+		expErr      bool
+		expContains []string
+	}{
+		"valid options are accepted": {
+			mutate: func(*Options) {},
+		},
+		"a disabled config is not validated at all": {
+			mutate: func(o *Options) {
+				o.Enabled = false
+				o.KeyAlgorithm = "not-a-real-algorithm"
+				o.MaxConcurrentReconciles = 0
+			},
+		},
+		"max-concurrent-reconciles below 1 is rejected": {
+			mutate:      func(o *Options) { o.MaxConcurrentReconciles = 0 },
+			expErr:      true,
+			expContains: []string{"max-concurrent-reconciles must be at least 1, got 0"},
+		},
+		"renew-before equal to the duration is rejected": {
+			mutate:      func(o *Options) { o.RenewBefore = o.Duration },
+			expErr:      true,
+			expContains: []string{"renew-before"},
+		},
+		"an RSA key below the minimum size is rejected": {
+			mutate:      func(o *Options) { o.KeySize = minRSAKeySize - 1 },
+			expErr:      true,
+			expContains: []string{"at least 2048 bits"},
+		},
+		"an unknown key algorithm is rejected": {
+			mutate:      func(o *Options) { o.KeyAlgorithm = "ed25519" },
+			expErr:      true,
+			expContains: []string{`invalid key algorithm "ED25519"`},
+		},
+		"an ECDSA key of an unsupported size is rejected": {
+			mutate: func(o *Options) {
+				o.KeyAlgorithm = "ECDSA"
+				o.KeySize = 521
+			},
+			expErr:      true,
+			expContains: []string{"256 or 384"},
+		},
+		// The offending name is what the operator has to go and correct, so it
+		// has to survive into the message.
+		"an invalid additional DNS name is reported with the name and the reason": {
+			mutate:      func(o *Options) { o.AdditionalDNSNames = []string{"NOT_A_DNS_NAME"} },
+			expErr:      true,
+			expContains: []string{`invalid additional DNS name "NOT_A_DNS_NAME"`, "lower case alphanumeric"},
+		},
+		"every invalid additional DNS name is reported": {
+			mutate: func(o *Options) {
+				o.AdditionalDNSNames = []string{"valid.example.com", "Bad.One", "worse_one"}
+			},
+			expErr:      true,
+			expContains: []string{`"Bad.One"`, `"worse_one"`},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			o := validOptions()
+			test.mutate(&o)
+
+			err := o.Validate()
+			if !test.expErr {
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatal("expected an error but got nil")
+			}
+
+			for _, want := range test.expContains {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("expected the error to mention %q, but got: %v", want, err)
+				}
+			}
+		})
+	}
+}
+
+// Validate fills in the defaults it documents through the flags, so those are
+// behaviour rather than an implementation detail.
+func TestOptionsValidateDefaults(t *testing.T) {
+	tests := map[string]struct {
+		algorithm    string
+		expKeySize   int
+		expCMKeyAlgo cmapi.PrivateKeyAlgorithm
+	}{
+		"RSA defaults to the minimum key size": {
+			algorithm:    "rsa",
+			expKeySize:   minRSAKeySize,
+			expCMKeyAlgo: cmapi.RSAKeyAlgorithm,
+		},
+		"ECDSA defaults to 256": {
+			algorithm:    "ecdsa",
+			expKeySize:   256,
+			expCMKeyAlgo: cmapi.ECDSAKeyAlgorithm,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			o := validOptions()
+			o.KeyAlgorithm = test.algorithm
+			o.KeySize = 0
+
+			if err := o.Validate(); err != nil {
+				t.Fatalf("expected no error but got: %v", err)
+			}
+
+			if o.KeySize != test.expKeySize {
+				t.Errorf("expected key size %d but got %d", test.expKeySize, o.KeySize)
+			}
+
+			if o.CMKeyAlgorithm != test.expCMKeyAlgo {
+				t.Errorf("expected cert-manager key algorithm %q but got %q", test.expCMKeyAlgo, o.CMKeyAlgorithm)
+			}
+
+			if o.KeyAlgorithm != strings.ToUpper(test.algorithm) {
+				t.Errorf("expected the algorithm to be upper-cased, but got %q", o.KeyAlgorithm)
+			}
+		})
+	}
+}


### PR DESCRIPTION
From the open follow-ups in cert-manager/cert-manager#9155:

> `istiodcert.Options.Validate` drops the invalid DNS name from its error: the `%q` meant for the name is given the joined validation errors instead, and the message ends with a dangling ": "

## The bug

```go
errs = append(errs, fmt.Errorf("invalid additional DNS name %q: ", strings.Join(validationErrors, ", ")))
```

The verb was meant for `name`. It gets the validation errors, and the `": "` at the end has nothing to print after it. So an operator who mistypes `--istiod-cert-additional-dns-names` sees this, at startup, for every bad name:

```
invalid additional DNS name "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric
characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com',
regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')": 
```

Every entry reads identically, whichever name was wrong. The one thing the operator has to go and correct — which of their names it was — is the one thing the message does not carry.

With the fix:

```
invalid additional DNS name "NOT_A_DNS_NAME": a lowercase RFC 1123 subdomain must consist of ...
```

## Why it survived

`Options.Validate` had no test file. This PR adds one, so the fix is pinned and the rest of the function is covered as well: the `max-concurrent-reconciles` and `renew-before` bounds, the RSA minimum and the ECDSA sizes, an unknown algorithm, the `Enabled: false` short-circuit, and the defaults `Validate` fills in (key size, `CMKeyAlgorithm`, and upper-casing the algorithm) — those are reachable through flags, so they are behaviour rather than an implementation detail.

## Verification

- **Revert-checked**: with `options.go` restored to `main` and the tests kept, exactly the two DNS-name cases fail, reproducing the message above verbatim. The other nine pass, so the new tests describe the existing behaviour rather than redefining it.
- `go test ./...`: every unit package green. `test/e2e` and `test/e2e-pure-runtime` fail identically on a pristine tree here — they need a cluster.
- `gofmt` clean.

---

*Written with assistance from Claude (Opus 5); the diagnosis, the fix and the results above were run and checked by me.*
